### PR TITLE
Force database

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -39,7 +39,7 @@ def main():
             logger.info('Requirements file %s found. Installing...', req)
             subprocess.check_call([pip, "install", "-r", req])
         logger.info('Testing module %s', module)
-        os.environ['OOTEST_MODULE'] = module
+        os.environ['DESTRAL_MODULE'] = module
         tests_module = 'addons.{}.tests'.format(module)
         logger.debug('Test module: %s', tests_module)
         try:

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -20,10 +20,9 @@ class OOTestCase(unittest.TestCase):
     def setUp(self):
         self.config = config_from_environment('DESTRAL', ['module'])
         self.openerp = OpenERPService()
-        self.openerp.db_name = self.openerp.create_database()
-        self.config = config_from_environment('OOTEST', ['module'])
-        self.openerp.install_module(self.config['module'])
-
+        if not self.openerp.db_name:
+            self.openerp.db_name = self.openerp.create_database()
+            self.openerp.install_module(self.config['module'])
 
     def test_all_views(self):
         logger.info('Testing views for module %s', self.config['module'])

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -18,6 +18,7 @@ class OOTestCase(unittest.TestCase):
         return self.openerp.db_name
 
     def setUp(self):
+        self.config = config_from_environment('DESTRAL', ['module'])
         self.openerp = OpenERPService()
         self.openerp.db_name = self.openerp.create_database()
         self.config = config_from_environment('OOTEST', ['module'])


### PR DESCRIPTION
Now we can use an existing database with the environment variable `OPENERP_DATABASE`.

**Note**: The module to test must be installed/updated before run the tests.

/cc @tinogis 