### PR TITLE
Improve module test detection

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import sys
 import subprocess
@@ -5,7 +6,7 @@ import unittest
 import logging
 
 import click
-from destral.utils import detect_module
+from destral.utils import detect_module, module_exists
 from destral.openerp import OpenERPService
 
 
@@ -47,6 +48,9 @@ def destral(modules, tests):
         os.environ['DESTRAL_MODULE'] = module
         tests_module = 'addons.{}.tests'.format(module)
         logger.debug('Test module: %s', tests_module)
+        # Module exists but there is an error show the error
+        if module_exists(tests_module) is None:
+            importlib.import_module(tests_module)
         if tests:
             tests = ['{}.{}'.format(tests_module, t) for t in tests]
             suite = unittest.TestLoader().loadTestsFromNames(tests)

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -1,3 +1,4 @@
+import imp
 import os
 
 
@@ -21,3 +22,18 @@ def detect_module(path):
         if '__terp__.py' in files:
             return module
     return None
+
+
+def module_exists(module):
+    modlist = module.split('.')
+    pathlist = None
+    for mod in modlist:
+        try:
+            openfile, pathname, desc = imp.find_module(mod, pathlist)
+            pathlist = [pathname]
+        except ImportError:
+            return False
+        else:
+            if openfile:
+                openfile.close()
+                return True


### PR DESCRIPTION
Before if tests are defined but there is some error loading the
module the result was the same as it doesn't exist. But it must
fail because the tests written are not executed.