### PR TITLE
Add mamba support

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -1,11 +1,13 @@
 import importlib
 import logging
+import os
 import unittest
 
 from destral.openerp import OpenERPService
 from destral.transaction import Transaction
 from destral.utils import module_exists
 from osconf import config_from_environment
+from mamba import application_factory
 
 
 logger = logging.getLogger('destral.testing')
@@ -138,3 +140,37 @@ def run_unittest_suite(suite):
         if k.startswith('report.'):
             del netsvc.SERVICES[k]
     return unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+def get_spec_suite(module):
+    """
+    Get spec suite to run Mamba
+    :param module: Module to get the spec suite
+    :return: suite
+    """
+    spec_dir = os.path.join(module, 'spec')
+    if os.path.exists(spec_dir):
+        # Create a fake arguments object
+        arguments = type('Arguments', (object, ), {})
+        arguments.specs = [spec_dir]
+        arguments.slow = 0.075
+        arguments.enable_coverage = False
+        arguments.format = 'progress'
+        arguments.no_color = True
+        arguments.watch = False
+        factory = application_factory.ApplicationFactory(arguments)
+        logger.info('Mamba application factory created for specs: {0}'.format(
+            spec_dir
+        ))
+        return factory.create_runner()
+    return None
+
+
+def run_spec_suite(suite):
+    """
+    Run Spec suite
+    :param suite: mamba Runner
+    :return:
+    """
+    suite.run()
+    return suite.reporter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-mamba
+doublex-expects

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     install_requires=[
         'osconf',
         'expects',
-        'click'
+        'click',
+        'mamba'
     ],
     license='GNU GPLv3',
     author='GISCE-TI, S.L.',

--- a/spec/testing_spec.py
+++ b/spec/testing_spec.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+import os
+import tempfile
+
+from destral.testing import get_spec_suite, run_spec_suite
+from expects import *
+from doublex_expects import *
+from doublex import Spy, method_returning
+from mamba.runners import BaseRunner
+from mamba.reporter import Reporter
+
+with description('Fixture#Mamba support'):
+    with it('has to create a runner if spec directory is present'):
+        module = tempfile.mkdtemp()
+
+        suite = get_spec_suite(module)
+        expect(suite).to(be(None))
+
+        spec_dir = os.path.join(module, 'spec')
+        os.mkdir(spec_dir)
+        suite = get_spec_suite(module)
+        expect(suite).to(be_a(BaseRunner))
+
+    with it('has to run the tests found in spec directory'):
+        module = tempfile.mkdtemp()
+        spec_dir = os.path.join(module, 'spec')
+        os.mkdir(spec_dir)
+        suite = get_spec_suite(module)
+        suite = Spy(suite)
+        suite.run = method_returning(True)
+        result = run_spec_suite(suite)
+        expect(result).to(be_a(Reporter))
+        expect(suite.run).to(have_been_called)


### PR DESCRIPTION
Add mamba support to destral

You can create `spec` tests adding a new directory to the root of the module with name `spec` and files with `_spec.py` to test

Closes #18 