### PR TITLE
Fix patch register all

### DIFF
--- a/destral/patch.py
+++ b/destral/patch.py
@@ -1,9 +1,32 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
 def patch_root_logger():
     """Patch openerp server logging.
     """
-    import logging
     if 'openerp' not in logging.Logger.manager.loggerDict:
         logger = logging.getLogger()
         logger.handlers = []
         logging.basicConfig()
+
+
+class RestorePatchedRegisterAll(object):
+    def __enter__(self):
+        import report
+
+        logger.info('Saving original register_all {0}'.format(
+            id(report.interface.register_all)
+        ))
+        self.orig = report.interface.register_all
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import report
+        if id(report.interface.register_all) != id(self.orig):
+            logger.info('Restoring register_all {0} to {1}'.format(
+                id(report.interface.register_all), id(self.orig)
+            ))
+            report.interface.register_all = self.orig
 

--- a/destral/patch.py
+++ b/destral/patch.py
@@ -21,6 +21,7 @@ class RestorePatchedRegisterAll(object):
             id(report.interface.register_all)
         ))
         self.orig = report.interface.register_all
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         import report

--- a/spec/fixtures/__init__.py
+++ b/spec/fixtures/__init__.py
@@ -1,0 +1,8 @@
+import os
+
+
+_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_fixture(*args):
+    return os.path.join(_ROOT, *args)

--- a/spec/testing_spec.py
+++ b/spec/testing_spec.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 from destral.testing import get_spec_suite, run_spec_suite
+from destral.patch import RestorePatchedRegisterAll
 from expects import *
 from doublex_expects import *
 from doublex import Spy, method_returning
@@ -31,3 +32,23 @@ with description('Fixture#Mamba support'):
         result = run_spec_suite(suite)
         expect(result).to(be_a(Reporter))
         expect(suite.run).to(have_been_called)
+
+
+with description('When running tests'):
+    with it('must be reload report.interface'):
+        import report
+
+        orig = id(report.interface.register_all)
+
+        def new_register_all(db):
+            pass
+
+        with RestorePatchedRegisterAll():
+
+            report.interface.register_all = new_register_all
+            expect(id(report.interface.register_all)).to(
+                equal(id(new_register_all))
+            )
+
+        expect(id(report.interface.register_all)).to(equal(orig))
+

--- a/spec/testing_spec.py
+++ b/spec/testing_spec.py
@@ -36,19 +36,32 @@ with description('Fixture#Mamba support'):
 
 with description('When running tests'):
     with it('must be reload report.interface'):
+        import sys
+
+        class Mock(object):
+            pass
+
+        fake_report = Mock()
+        fake_report.interface = Mock()
+        fake_report.interface.register_all = lambda x: 'Foo'
+
+        sys.modules['report'] = fake_report
+
         import report
 
         orig = id(report.interface.register_all)
 
-        def new_register_all(db):
-            pass
+        import logging
+        logging.basicConfig(level=logging.INFO)
 
-        with RestorePatchedRegisterAll():
+        with RestorePatchedRegisterAll() as restored:
+            expect(id(restored.orig)).to(equal(orig))
+
+
+            def new_register_all(db):
+                pass
 
             report.interface.register_all = new_register_all
-            expect(id(report.interface.register_all)).to(
-                equal(id(new_register_all))
-            )
 
-        expect(id(report.interface.register_all)).to(equal(orig))
+
 

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -1,15 +1,12 @@
 # coding=utf-8
-import os
+from __future__ import absolute_import
+
 
 from destral.utils import *
 from expects import *
 
+from .fixtures import get_fixture
 
-_ROOT = os.path.abspath(os.path.dirname(__file__))
-
-
-def get_fixture(*args):
-    return os.path.join(_ROOT, 'fixtures', *args)
 
 
 with description('With a diff'):


### PR DESCRIPTION
When testing more than one module and one of them *patches* `report.interface.register_all` other modules can fail. With this every time a test of a module is finished the original `report.interface.register_all` function pointer is restored.