### PR TITLE
[FIX] Result DB Name

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -42,8 +42,9 @@ class OOTestSuite(unittest.TestSuite):
                 self.openerp.db_name = self.openerp.create_database(
                     self.config['use_template']
                 )
-                result.db_name = self.openerp.db_name
+
                 self.drop_database = True
+            result.db_name = self.openerp.db_name
             self.openerp.install_module(self.config['module'])
         else:
             self.openerp.db_name = result.db_name


### PR DESCRIPTION
Always assign db_name to `result` test. Because if we use an existing database the `result` test object didn't have `db_name` attribute.