### PR TITLE
Enable coverage

### DIFF
--- a/destral/cover.py
+++ b/destral/cover.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+from __future__ import absolute_import
+
+from coverage import Coverage
+
+
+class OOCoverage(Coverage):
+    def __init__(self, *args, **kwargs):
+        self.enabled = True
+        super(OOCoverage, self).__init__(*args, **kwargs)
+
+    def start(self):
+        if self.enabled:
+            super(OOCoverage, self).start()
+
+    def stop(self):
+        if self.enabled:
+            super(OOCoverage, self).stop()

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -12,7 +12,8 @@ __all__ = [
     'module_exists',
     'get_dependencies',
     'find_files',
-    'install_requirements'
+    'install_requirements',
+    'coverage_modules_path'
 ]
 
 
@@ -133,3 +134,10 @@ def install_requirements(module, addons_path):
         if os.path.exists(req) and os.path.exists(pip):
             logger.info('Requirements file %s found. Installing...', req)
             subprocess.check_call([pip, "install", "-r", req])
+
+
+def coverage_modules_path(modules_to_test, addons_path):
+    return [
+        os.path.relpath(os.path.realpath(os.path.join(addons_path, m))) for m in
+        modules_to_test
+    ]

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -9,6 +9,7 @@ command are::
   Usage: destral [OPTIONS]
 
     Options:
+      --enable-coverage
       -m, --modules TEXT
       -t, --tests TEXT
       --help              Show this message and exit.
@@ -21,6 +22,11 @@ If no specific tests are defined into the module, *destral* will test:
   * Correct installation of the module.
   * All the views defined in the module are ok.
   * Definition of access rules for all the models of the module
+
+If you have run with the `--enable-coverage` option a `.coverage` file will be
+generated with the results and you can see the report executing::
+
+  $ coverage report
 
 
 Configuring destral

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,3 +31,10 @@ destral.utils
 
 .. automodule:: destral.utils
    :members:
+
+
+destral.cover
+=============
+
+.. automodule:: destral.cover
+   :members:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
         'osconf',
         'expects',
         'click',
-        'mamba'
+        'mamba',
+        'coverage'
     ],
     license='GNU GPLv3',
     author='GISCE-TI, S.L.',


### PR DESCRIPTION
Now is possible to **run destral with coverage** to know the lines executing during the test.

For now the system only includes the lines of the module. To run with coverage:

```sh
$ destral --enable-coverage -m module_to_test
```
Then you can see the report executing

```sh
$ coverage report
```