### PR TITLE
Add option to print the report coverage

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -23,7 +23,8 @@ logger = logging.getLogger('destral.cli')
 @click.option('--modules', '-m', multiple=True)
 @click.option('--tests', '-t', multiple=True)
 @click.option('--enable-coverage', type=click.BOOL, default=False, is_flag=True)
-def destral(modules, tests, enable_coverage=None):
+@click.option('--report-coverage', type=click.BOOL, default=False, is_flag=True)
+def destral(modules, tests, enable_coverage=None, report_coverage=None):
     sys.argv = sys.argv[:1]
     service = OpenERPService()
     if not modules:
@@ -65,7 +66,7 @@ def destral(modules, tests, enable_coverage=None):
     coverage = OOCoverage(
         source=coverage_modules_path(modules_to_test, addons_path)
     )
-    coverage.enabled = enable_coverage
+    coverage.enabled = (enable_coverage or report_coverage)
 
     server_spec_suite = get_spec_suite(root_path)
     if server_spec_suite:
@@ -90,6 +91,9 @@ def destral(modules, tests, enable_coverage=None):
             result = run_unittest_suite(suite)
             coverage.stop()
             results.append(result.wasSuccessful())
+    if report_coverage:
+        coverage.report()
+    if enable_coverage:
         coverage.save()
 
     if not all(results):

--- a/destral/cover.py
+++ b/destral/cover.py
@@ -16,3 +16,7 @@ class OOCoverage(Coverage):
     def stop(self):
         if self.enabled:
             super(OOCoverage, self).stop()
+
+    def report(self, *args, **kwargs):
+        if self.enabled:
+            return super(OOCoverage, self).report(*args, **kwargs)

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -10,6 +10,7 @@ command are::
 
     Options:
       --enable-coverage
+      --report-coverage
       -m, --modules TEXT
       -t, --tests TEXT
       --help              Show this message and exit.


### PR DESCRIPTION
Add an option to print the coverage report doing:

```sh
$ destral --report-coverage -m module_to_test
```