### PR TITLE
Fix: Netsvc doesn't allways clear

### DIFF
--- a/destral/utils.py
+++ b/destral/utils.py
@@ -61,6 +61,9 @@ def module_exists(module):
         try:
             openfile, pathname, desc = imp.find_module(mod, pathlist)
             pathlist = [pathname]
+            # Clean netsvc Services
+            import netsvc
+            netsvc.SERVICES.clear()
         except ImportError:
             return False
         else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-doublex-expects>=0.6
+doublex-expects>=0.7.0rc2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-doublex-expects>0.6
+doublex-expects>=0.6


### PR DESCRIPTION
Fixed an error where the netsvc wouldn't be cleared after checking if a module exists.