### PR TITLE
If no-drodb is used enable admin user

### DIFF
--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -133,3 +133,16 @@ class OpenERPService(object):
         self.db, self.pool = pooler.restart_pool(
             self.config['db_name'], update_module=True
         )
+
+    def enable_admin(self, password='admin'):
+        from destral.transaction import Transaction
+        with Transaction().start(self.config['db_name']) as txn:
+            user_obj = self.pool.get('res.users')
+            user_ids = user_obj.search(txn.cursor, txn.user, [
+                ('login', '=', 'admin')
+            ])
+            user_obj.write(txn.cursor, txn.user, user_ids, {
+                'password': password
+            })
+            txn.cursor.commit()
+            logger.info('User admin enabled with password: %s', password)

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -56,6 +56,8 @@ class OOTestSuite(unittest.TestSuite):
             if self.drop_database:
                 self.openerp.drop_database()
                 self.openerp.db_name = False
+            else:
+                self.openerp.enable_admin()
         return res
 
     def _handleClassSetUp(self, test, result):


### PR DESCRIPTION
Before this patch, when using `no-dropdb` if we want to use the database with the client, we must update the `res_users` table setting a password for `admin` user.
With this patch the `admin` user is enabled with `admin` password.