### PR TITLE
Better no dropdb

### DIFF
--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -139,10 +139,15 @@ class OpenERPService(object):
         with Transaction().start(self.config['db_name']) as txn:
             user_obj = self.pool.get('res.users')
             user_ids = user_obj.search(txn.cursor, txn.user, [
-                ('login', '=', 'admin')
-            ])
-            user_obj.write(txn.cursor, txn.user, user_ids, {
-                'password': password
-            })
-            txn.cursor.commit()
-            logger.info('User admin enabled with password: %s', password)
+                ('login', '=', 'admin'),
+                ('password', '=', False)
+            ], context={'active_test': False})
+            if user_ids:
+                user_obj.write(txn.cursor, txn.user, user_ids, {
+                    'active': True,
+                    'password': password
+                })
+                txn.cursor.commit()
+                logger.info(
+                    'User admin enabled with password: %s on %s',
+                    password, txn.cursor.dbname)

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -57,6 +57,7 @@ class OOTestSuite(unittest.TestSuite):
                 self.openerp.drop_database()
                 self.openerp.db_name = False
             else:
+                logger.info('Not dropping database %s', self.openerp.db_name)
                 self.openerp.enable_admin()
         return res
 


### PR DESCRIPTION
Better enabled user admin:
  - Only if it doesn't have password setted
  - Search for active/no active
  - Writes active:True

Log with the database name when not dropping