### PR TITLE
Patch cursor to not commit, rollback or close

### DIFF
--- a/destral/patch.py
+++ b/destral/patch.py
@@ -41,6 +41,14 @@ class PatchedCursor(object):
 
 
 class PatchedConnection(object):
+    """Patched connection wapper to return the same cursor.
+
+    This is useful when some method inside a testing mehtod creates new
+    cursors.
+
+    :param connection: Original connection
+    :param cursor: Original cursor
+    """
 
     def __init__(self, connection, cursor):
         self._connection = connection
@@ -50,10 +58,16 @@ class PatchedConnection(object):
         return getattr(self._connection, item)
 
     def cursor(self, serialized=False):
+        """Wrapped function to return the same cursor
+        """
         return self._cursor
 
 
 class PatchNewCursors(object):
+    """Util to patch creation of new cursor.
+
+    This will always return the cursor created by Transaction
+    """
 
     @staticmethod
     def db_connect(db_name):
@@ -62,9 +76,6 @@ class PatchNewCursors(object):
         cursor = Transaction().cursor
         conn = sql_db.Connection(sql_db._Pool, db_name)
         return PatchedConnection(conn, cursor)
-
-    def __init__(self, cursor):
-        self.cursor = cursor
 
     def __enter__(self):
         import sql_db

--- a/spec/patch_spec.py
+++ b/spec/patch_spec.py
@@ -1,0 +1,18 @@
+from expects import *
+
+
+with description('Wrapping Cursor object'):
+    with it('must return True on commit, rollback and close'):
+        from destral.patch import PatchedCursor
+
+        class MockCursor(object):
+            def execute(self, sql):
+                return 'execute', sql
+
+        p = PatchedCursor(MockCursor())
+
+        expect(p.commit()).to(be_true)
+        expect(p.rollback()).to(be_true)
+        expect(p.close()).to(be_true)
+
+        expect(p.execute('select 1')).to(equal(('execute', 'select 1')))


### PR DESCRIPTION
Added a class to *patch* the cursor creation.

In the tests **no commit** is needed but when we make a new cursor the visibility from the other cursor is hiden, for thus we have patched the creation of new cursos and using the same cursor.

If we have to test some method that create a new cursor we can do the following:

```python
with Transaction().start(self.database) as txn:
    cursor = txn.cursor
    with PatchNewCursors(cursor):
        db = pooler.get_db_only(cursor.dbname)
        new_cursor = db.cursor()
        expect(cursor).to(be(new_cursor)
```