### PR TITLE
[To Merge] Add missing strings pofiles

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -208,11 +208,19 @@ class OOBaseTests(OOTestCase):
             )
             # Don't compare untranslated strings in POT
             #   because POT files do not contain translations
-            self.assertFalse(
+            self.assertIsNotNone(
+                missing_strings,
+                'There is not a POT file for module {}'.format(
+                    self.config['module']
+                )
+            )
+            self.assertItemsEqual(
+                [],
                 missing_strings,
                 'There are {} missing strings in the POT file'
-                ' of the module {}'.format(
-                    missing_strings, self.config['module']
+                ' of the module {}\nThe missing strings are:\n{}'.format(
+                    len(missing_strings), self.config['module'],
+                    '\n'.join(missing_strings)
                 )
             )
             logger.info('Checking translations for langs: {}'.format(

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -231,18 +231,30 @@ class OOBaseTests(OOTestCase):
                 missing_strings, untranslated_strings = compare_pofiles(
                     tmp_pot, po_path
                 )
-                self.assertFalse(
+                self.assertIsNotNone(
                     missing_strings,
-                    'There are {} missing strings in the PO file'
-                    ' of the module {}'.format(
-                        untranslated_strings, self.config['module']
+                    'There is not a PO file for module {}'
+                    ' with locale: "{}"'.format(
+                        self.config['module'], test_lang
                     )
                 )
-                self.assertFalse(
+                self.assertItemsEqual(
+                    [],
+                    missing_strings,
+                    'There are {} missing strings in the PO file'
+                    ' of the module {}\nThe missing strings are:\n{}'.format(
+                        len(missing_strings), self.config['module'],
+                        '\n'.join(missing_strings)
+                    )
+                )
+                self.assertItemsEqual(
+                    [],
                     untranslated_strings,
                     'There are {} untranslated strings in the PO file'
-                    ' of the module {}'.format(
-                        untranslated_strings, self.config['module']
+                    ' of the module {}\nThe untranslated strings are:\n'
+                    '>>>\n{}\n<<<'.format(
+                        len(untranslated_strings), self.config['module'],
+                        '\n'.join(untranslated_strings)
                     )
                 )
 

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -161,10 +161,10 @@ def compare_pofiles(pathA, pathB):
     logger = logging.getLogger('destral.utils.compare_pofiles')
     if not isfile(pathA):
         logger.info('Could not get po/pot file: {}'.format(pathA))
-        return -1, -1
+        return [], []
     elif not isfile(pathB):
         logger.info('Could not get po/pot file: {}'.format(pathB))
-        return -1, -1
+        return [], []
     try:
         with open(pathA, 'r') as potA:
             fileA = pofile.read_po(potA)

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -201,17 +201,17 @@ def compare_pofiles(pathA, pathB):
             'Data of POfile {} has bad formatted '
             'creation or revision dates'.format(pathB)
         )
-    not_found = 0
-    not_translated = 0
+    not_found = []
+    not_translated = []
     for msgA in fileA:
         if msgA.id == '':
             continue
         msgB = fileB.get(msgA.id)
         if not msgB:
-            not_found += 1
+            not_found.append(msgA.id)
             continue
         if not msgB.string:
-            not_translated += 1
+            not_translated.append(msgA.id)
     return not_found, not_translated
 
 

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -161,10 +161,10 @@ def compare_pofiles(pathA, pathB):
     logger = logging.getLogger('destral.utils.compare_pofiles')
     if not isfile(pathA):
         logger.info('Could not get po/pot file: {}'.format(pathA))
-        return False, False
+        return None, None
     elif not isfile(pathB):
         logger.info('Could not get po/pot file: {}'.format(pathB))
-        return False, False
+        return None, None
     try:
         with open(pathA, 'r') as potA:
             fileA = pofile.read_po(potA)

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -161,10 +161,10 @@ def compare_pofiles(pathA, pathB):
     logger = logging.getLogger('destral.utils.compare_pofiles')
     if not isfile(pathA):
         logger.info('Could not get po/pot file: {}'.format(pathA))
-        return [], []
+        return False, False
     elif not isfile(pathB):
         logger.info('Could not get po/pot file: {}'.format(pathB))
-        return [], []
+        return False, False
     try:
         with open(pathA, 'r') as potA:
             fileA = pofile.read_po(potA)

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -48,9 +48,7 @@ with description('Translations'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('pofileB.po')  # Has 1 message untranslated
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
-            expect(len(missing_msg)).to(equal(0))
             expect(missing_msg).to(equal([]))
-            expect(len(untranslated_msg)).to(equal(1))
             expect(untranslated_msg).to(equal([(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
                 "Suspendisse posuere iaculis mauris. Aliquam ornare ante lectus,"

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -64,3 +64,7 @@ with description('Translations'):
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathD)
             expect(untranslated_msg).to(equal(False))
             expect(missing_msg).to(equal(False))
+            # invert POT positions
+            missing_msg, untranslated_msg = compare_pofiles(pathD, pathA)
+            expect(untranslated_msg).to(equal(False))
+            expect(missing_msg).to(equal(False))

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -43,7 +43,13 @@ with description('Translations'):
             pathC = get_fixture('pofileB.po')  # Has 1 message untranslated
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
             expect(len(missing_msg)).to(equal(0))
+            expect(missing_msg).to(equal([]))
             expect(len(untranslated_msg)).to(equal(1))
+            expect(untranslated_msg).to(equal([(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                "Suspendisse posuere iaculis mauris. Aliquam ornare ante lectus,"
+                "nec feugiat nunc dignissim in."
+            )]))
         with it('Compare POT files with one missing POT file'):
             pathA = get_fixture('potfileA.pot')
             pathD = get_fixture('potfileC.pot')  # Does not exist

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -37,7 +37,7 @@ with description('Translations'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('potfileB.pot')  # Has 2 less messages than A
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
-            expect(untranslated_msg).to(equal([
+            expect(missing_msg).to(equal([
                 "One String", "A Larger string!!!!"
             ]))
             expect(untranslated_msg).to(equal([(

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -36,8 +36,14 @@ with description('Translations'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('potfileB.pot')  # Has 2 less messages than A
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
-            expect(len(untranslated_msg)).to(equal(1))
-            expect(len(missing_msg)).to(equal(2))
+            expect(untranslated_msg).to(equal([
+                "One String", "A Larger string!!!!"
+            ]))
+            expect(untranslated_msg).to(equal([(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                "Suspendisse posuere iaculis mauris. Aliquam ornare ante lectus,"
+                "nec feugiat nunc dignissim in."
+            )]))
         with it('Compare POT and PO files missing 1 translation'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('pofileB.po')  # Has 1 message untranslated

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -25,14 +25,15 @@ with description('With a diff'):
 
 with description('Translations'):
     with context('Comparing pofiles'):
-        with it('Compare the POT and PO files with the same msg id and string'):
+        with it('must return empty lists when the POT and PO files have'
+                ' the same msg id and string'):
             pathA = get_fixture('potfileA.pot')
             pathB = get_fixture('pofileA.po')
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathB)
             expect(untranslated_msg).to(equal([]))
             expect(missing_msg).to(equal([]))
-        with it('Compare PO files with one PO missing'
-                ' 2 strings and 1 untranslated'):
+        with it('must return a tuple with the missing and untranslated strings'
+                ' when the PO files have 2 missing strings and 1 untranslated'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('potfileB.pot')  # Has 2 less messages than A
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
@@ -44,7 +45,9 @@ with description('Translations'):
                 "Suspendisse posuere iaculis mauris. Aliquam ornare ante lectus,"
                 "nec feugiat nunc dignissim in."
             )]))
-        with it('Compare POT and PO files missing 1 translation'):
+        with it('must return an empty list for the missing strings and a list'
+                ' with the untranslated string when the POT and PO files have'
+                ' 1 missing translation'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('pofileB.po')  # Has 1 message untranslated
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
@@ -54,7 +57,8 @@ with description('Translations'):
                 "Suspendisse posuere iaculis mauris. Aliquam ornare ante lectus,"
                 "nec feugiat nunc dignissim in."
             )]))
-        with it('Compare POT files with one missing POT file'):
+        with it('must return booleans (False) for both lists when any of the'
+                ' POT files cannot be found'):
             pathA = get_fixture('potfileA.pot')
             pathD = get_fixture('potfileC.pot')  # Does not exist
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathD)

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -29,8 +29,8 @@ with description('Translations'):
             pathA = get_fixture('potfileA.pot')
             pathB = get_fixture('pofileA.po')
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathB)
-            expect(len(untranslated_msg)).to(equal(0))
-            expect(len(missing_msg)).to(equal(0))
+            expect(untranslated_msg).to(equal([]))
+            expect(missing_msg).to(equal([]))
         with it('Compare PO files with one PO missing'
                 ' 2 strings and 1 untranslated'):
             pathA = get_fixture('potfileA.pot')

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -48,5 +48,5 @@ with description('Translations'):
             pathA = get_fixture('potfileA.pot')
             pathD = get_fixture('potfileC.pot')  # Does not exist
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathD)
-            expect(len(untranslated_msg)).to(equal(-1))
-            expect(len(missing_msg)).to(equal(-1))
+            expect(untranslated_msg).to(equal(False))
+            expect(missing_msg).to(equal(False))

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -62,9 +62,9 @@ with description('Translations'):
             pathA = get_fixture('potfileA.pot')
             pathD = get_fixture('potfileC.pot')  # Does not exist
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathD)
-            expect(untranslated_msg).to(equal(False))
-            expect(missing_msg).to(equal(False))
+            expect(untranslated_msg).to(be_none)
+            expect(missing_msg).to(be_none)
             # invert POT positions
             missing_msg, untranslated_msg = compare_pofiles(pathD, pathA)
-            expect(untranslated_msg).to(equal(False))
-            expect(missing_msg).to(equal(False))
+            expect(untranslated_msg).to(be_none)
+            expect(missing_msg).to(be_none)

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -29,24 +29,24 @@ with description('Translations'):
             pathA = get_fixture('potfileA.pot')
             pathB = get_fixture('pofileA.po')
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathB)
-            expect(untranslated_msg).to(equal(0))
-            expect(missing_msg).to(equal(0))
+            expect(len(untranslated_msg)).to(equal(0))
+            expect(len(missing_msg)).to(equal(0))
         with it('Compare PO files with one PO missing'
                 ' 2 strings and 1 untranslated'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('potfileB.pot')  # Has 2 less messages than A
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
-            expect(untranslated_msg).to(equal(1))
-            expect(missing_msg).to(equal(2))
+            expect(len(untranslated_msg)).to(equal(1))
+            expect(len(missing_msg)).to(equal(2))
         with it('Compare POT and PO files missing 1 translation'):
             pathA = get_fixture('potfileA.pot')
             pathC = get_fixture('pofileB.po')  # Has 1 message untranslated
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathC)
-            expect(missing_msg).to(equal(0))
-            expect(untranslated_msg).to(equal(1))
+            expect(len(missing_msg)).to(equal(0))
+            expect(len(untranslated_msg)).to(equal(1))
         with it('Compare POT files with one missing POT file'):
             pathA = get_fixture('potfileA.pot')
             pathD = get_fixture('potfileC.pot')  # Does not exist
             missing_msg, untranslated_msg = compare_pofiles(pathA, pathD)
-            expect(untranslated_msg).to(equal(-1))
-            expect(missing_msg).to(equal(-1))
+            expect(len(untranslated_msg)).to(equal(-1))
+            expect(len(missing_msg)).to(equal(-1))


### PR DESCRIPTION
Closes #78

Add missing and untranslated strings list on log when test fails

- [x] Update tests for the utils method (compare pofiles) as they should now return str lists
- [x] Update _utils.py_ method "compare_pofiles" to return missing/untranslated strings with lists instead of length
- [x] Update _testing.py_ method "test_translate_modules" to log missing/untranslated strings for the module it tests