### PR TITLE
FIX: Generate pot file correctlly

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -193,7 +193,7 @@ class OOBaseTests(OOTestCase):
             # Generate POT data from loaded strings
             trans_data = StringIO()
             trans_export(
-                self.config['testing_langs'][0], self.config['module'],
+                False, [self.config['module']],
                 trans_data, 'po', dbname=cursor.dbname
             )
 


### PR DESCRIPTION
Pass a list of modules instead of a single module to translate method.
The single module was managed as a list of chars and pot file was wrongly generated. Passing a list of modules each element of the list is a module and the strings are generated correctly.

Solves https://github.com/gisce/destral/issues/80.
