### PR TITLE
Add Report Translations Check

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -196,6 +196,10 @@ class OOBaseTests(OOTestCase):
                 False, [self.config['module']],
                 trans_data, 'po', dbname=cursor.dbname
             )
+            trans_obj = self.openerp.pool.get('wizard.module.lang.export')
+            trans_data = trans_obj.append_report_translations(
+                txn.cursor, txn.user, self.config['module'], 'pot', trans_data
+            )
 
         with TempDir() as temp:
             tmp_pot = '{}/{}.pot'.format(temp.dir, self.config['module'])

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -198,7 +198,7 @@ class OOBaseTests(OOTestCase):
             )
             trans_obj = self.openerp.pool.get('wizard.module.lang.export')
             trans_data = trans_obj.append_report_translations(
-                txn.cursor, txn.user, self.config['module'], 'pot', trans_data
+                txn.cursor, txn.user, [self.config['module']], 'pot', trans_data
             )
 
         with TempDir() as temp:


### PR DESCRIPTION
Check report translations for each module using new method from [gisce/erp#4972](https://github.com/gisce/erp/pull/4972)

Report translatable strings are being lost due to wrong process of translations to fix module translations. 
→ Test Translations is making developers erase report translations
→ Including those strings, the translations won't be lost