### PR TITLE
Changed the return method of a tests in case of one module not having translations

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -172,8 +172,11 @@ class OOBaseTests(OOTestCase):
             self.openerp.config['addons_path'], self.config['module']
         )
         trad_path = join(mod_path, 'i18n')
-        
-        self.assertTrue(isdir(trad_path), ('Module %s has no translations', self.config['module']))
+
+        self.assertTrue(
+            isdir(trad_path),
+            'Module {} has no translations'.format(self.config['module'])
+        )
 
         if not self.config['testing_langs']:
             logger.warning(

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -172,11 +172,8 @@ class OOBaseTests(OOTestCase):
             self.openerp.config['addons_path'], self.config['module']
         )
         trad_path = join(mod_path, 'i18n')
-        if not isdir(trad_path):
-            logger.warning(
-                'Module %s has no translations', self.config['module']
-            )
-            return
+        
+        self.assertTrue(isdir(trad_path), ('Module %s has no translations', self.config['module']))
 
         if not self.config['testing_langs']:
             logger.warning(


### PR DESCRIPTION
Closes https://github.com/gisce/destral/issues/83

Changed the behaviour of the test in the case of some module not having translations. Instead of skipping the test, it will make the test fail.