### PR TITLE
Fix for new mamba 0.9.1 version

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -321,6 +321,7 @@ def get_spec_suite(module):
         arguments.format = 'progress'
         arguments.no_color = True
         arguments.watch = False
+        arguments.coverage_file = '.coverage'
         factory = application_factory.ApplicationFactory(arguments)
         logger.info('Mamba application factory created for specs: {0}'.format(
             spec_dir


### PR DESCRIPTION
## Error

Drone is giving the following error:
```
$ destral --report-coverage
2017-12-11 15:35:20,671:INFO:destral.cli:Files from Pull Request: 5740: addons/spain/l10n_es_extras/l10n_ES_aeat_sii/scripts/execute_sii_workers.py
2017-12-11 15:35:20,811:INFO:destral.testing:Mamba application factory created for specs: /drone/src/github.com/gisce/erp/server/bin/spec
Traceback (most recent call last):
  File "/home/erp/bin/destral", line 11, in <module>
Encoding ascii => UTF-8
    load_entry_point('destral==0.22.6', 'console_scripts', 'destral')()
  File "/home/erp/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/erp/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/erp/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/erp/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/erp/lib/python2.7/site-packages/destral/cli.py", line 86, in destral
    server_spec_suite = get_spec_suite(root_path)
  File "/home/erp/lib/python2.7/site-packages/destral/testing.py", line 328, in get_spec_suite
    return factory.create_runner()
  File "/home/erp/lib/python2.7/site-packages/mamba/application_factory.py", line 36, in create_runner
    settings = self.create_settings()
  File "/home/erp/lib/python2.7/site-packages/mamba/application_factory.py", line 16, in create_settings
    settings_.code_coverage_file = self.arguments.coverage_file
AttributeError: type object 'Arguments' has no attribute 'coverage_file'
[info] build failed (exit code 1)
```

## Pull Request

The new `mamba` version 0.9.1 [needs a coverage-file](https://github.com/nestorsalceda/mamba/commit/baf2be0db2d556e2ef4d188c93342520fc5cebaa#diff-01e15ca2bdb719e7d363ef0f45bfc2e2) in the arguments.