### PR TITLE
SET required mamba version to 0.8.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'osconf',
         'expects',
         'click',
-        'mamba',
+        'mamba==0.8.6',
         'coverage',
         'python-dateutil',
         'babel>=2.4.0'


### PR DESCRIPTION
Mamba has updated its version and it generates an error on our use of it. Setting the version to the 0.8.6 will fix the problem.