### PR TITLE
Remove Exception type to catch all exceptions

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -36,12 +36,12 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
         ci_pull_request = os.environ.get('CI_PULL_REQUEST')
         token = os.environ.get('GITHUB_TOKEN')
         repository = os.environ.get('CI_REPO')
-        try:
-            int(ci_pull_request)
-        except:
-            # If CI_PULL_REQUEST contains URL instead of PR number, get it
-            ci_pull_request = ci_pull_request.split('/')[-1]
         if ci_pull_request and token and repository:
+            try:
+                int(ci_pull_request)
+            except:
+                # If CI_PULL_REQUEST contains URL instead of PR number, get it
+                ci_pull_request = ci_pull_request.split('/')[-1]
             url = 'https://api.github.com/repos/{repo}/pulls/{pr_number}'.format(
                 repo=repository,
                 pr_number=ci_pull_request

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -38,7 +38,7 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
         repository = os.environ.get('CI_REPO')
         try:
             int(ci_pull_request)
-        except ValueError:
+        except:
             # If CI_PULL_REQUEST contains URL instead of PR number, get it
             ci_pull_request = ci_pull_request.split('/')[-1]
         if ci_pull_request and token and repository:


### PR DESCRIPTION
Failin when no PR is set as it tries to parse the "CI_PULL_REQUEST" but it's not set yet