### PR TITLE
[TMP] ADD translation export

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -24,13 +24,20 @@ logger = logging.getLogger('destral.cli')
     allow_extra_args=True))
 @click.option('--modules', '-m', multiple=True)
 @click.option('--tests', '-t', multiple=True)
+@click.option(
+    '--export-translations', type=click.BOOL, default=False, is_flag=True)
 @click.option('--enable-coverage', type=click.BOOL, default=False, is_flag=True)
 @click.option('--report-coverage', type=click.BOOL, default=False, is_flag=True)
 @click.option('--dropdb/--no-dropdb', default=True)
 @click.option('--requirements/--no-requirements', default=True)
-def destral(modules, tests, enable_coverage=None, report_coverage=None,
-            dropdb=None, requirements=None):
+def destral(modules, tests, export_translations=None, enable_coverage=None,
+            report_coverage=None, dropdb=None, requirements=None):
     sys.argv = sys.argv[:1]
+    if not os.environ['DESTRAL_EXPORT_TRANSLATIONS'] and export_translations:
+        os.environ['DESTRAL_EXPORT_TRANSLATIONS'] = export_translations
+    export_translations = os.environ['DESTRAL_EXPORT_TRANSLATIONS']
+    if export_translations:
+        tests = ['OOBaseTests.test_translate_modules']
     service = OpenERPService()
     if not modules:
         ci_pull_request = os.environ.get('CI_PULL_REQUEST')

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -30,12 +30,14 @@ logger = logging.getLogger('destral.cli')
 @click.option('--report-coverage', type=click.BOOL, default=False, is_flag=True)
 @click.option('--dropdb/--no-dropdb', default=True)
 @click.option('--requirements/--no-requirements', default=True)
-def destral(modules, tests, export_translations=None, enable_coverage=None,
+def destral(modules, tests, export_translations=False, enable_coverage=None,
             report_coverage=None, dropdb=None, requirements=None):
     sys.argv = sys.argv[:1]
-    if not os.environ['DESTRAL_EXPORT_TRANSLATIONS'] and export_translations:
-        os.environ['DESTRAL_EXPORT_TRANSLATIONS'] = export_translations
-    export_translations = os.environ['DESTRAL_EXPORT_TRANSLATIONS']
+    if not export_translations:
+        export_translations = False
+    if not os.environ.get('DESTRAL_EXPORT_TRANSLATIONS', False):
+        os.environ['DESTRAL_EXPORT_TRANSLATIONS'] = str(export_translations)
+    export_translations = eval(os.environ.get('DESTRAL_EXPORT_TRANSLATIONS', "False"))
     if export_translations:
         tests = ['OOBaseTests.test_translate_modules']
     service = OpenERPService()

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -18,8 +18,8 @@ class OOTestSuite(unittest.TestSuite):
     def __init__(self, tests=()):
         super(OOTestSuite, self).__init__(tests)
         self.config = config_from_environment(
-            'DESTRAL', ['module', 'testing_langs'],
-            use_template=True, testing_langs=[]
+            'DESTRAL', ['module', 'testing_langs', 'export_translations'],
+            use_template=True, testing_langs=[], export_translations=False
         )
         ooconfig = {}
         self.config['use_template'] = False
@@ -202,6 +202,14 @@ class OOBaseTests(OOTestCase):
             trans_data = trans_obj.append_report_translations(
                 txn.cursor, txn.user, [self.config['module']], 'pot', trans_data
             )
+        if self.config['export_translations']:
+            with open(
+                    join(
+                        mod_path, 'i18n',
+                        '{modname}.pot'.format(modname=self.config['module'])
+                    ), 'w') as pot:
+                pot.write(trans_data.getvalue())
+            return True
 
         with TempDir() as temp:
             tmp_pot = '{}/{}.pot'.format(temp.dir, self.config['module'])


### PR DESCRIPTION
Adds the "`--export-translations`" parameter, allowing the "user" to export translations on the testing module/modules