### PR TITLE
Add export junitxml

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -132,7 +132,7 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
             coverage.stop()
             results.append(result.wasSuccessful())
             if report_junitxml:
-                junitxml_suites.append(result.get_test_suites())
+                junitxml_suites.append(result.get_test_suite(module))
     if report_junitxml:
         from junit_xml import TestSuite
         for suite in junitxml_suites:

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -38,7 +38,7 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
     else:
         report_junitxml = os.environ.get('DESTRAL_JUNITXML', False)
     if report_junitxml:
-        junitxml_directory = os.path.dirname(os.path.abspath(report_junitxml))
+        junitxml_directory = os.path.abspath(report_junitxml)
         if not os.path.isdir(junitxml_directory):
             os.makedirs(junitxml_directory)
     if not modules:
@@ -135,8 +135,11 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
                 junitxml_suites.append(result.get_test_suites())
     if report_junitxml:
         from junit_xml import TestSuite
-        with open(report_junitxml, 'w') as report_file:
-            report_file.write(TestSuite.to_xml_string(junitxml_suites))
+        for suite in junitxml_suites:
+            with open(
+                    os.path.join(report_junitxml, suite.name+'.xml'), 'w'
+            ) as report_file:
+                report_file.write(TestSuite.to_xml_string([suite]))
     if report_coverage:
         coverage.report()
     if enable_coverage:

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -135,7 +135,7 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
                 junitxml_suites.append(result.get_test_suites())
     if report_junitxml:
         from junit_xml import TestSuite
-        with open(report_junitxml, 'a') as report_file:
+        with open(report_junitxml, 'w') as report_file:
             report_file.write(TestSuite.to_xml_string(junitxml_suites))
     if report_coverage:
         coverage.report()

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -124,7 +124,7 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
             suite.drop_database = dropdb
             result = run_unittest_suite(suite)
             coverage.stop()
-            results.append(result.wasSuccessful())
+            results.append(result)
     if report_junitxml:
         for result in results:
             if result.get('junit_suite', False):
@@ -135,7 +135,7 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
     if enable_coverage:
         coverage.save()
 
-    if not all(results):
+    if not all([r.wasSuccessful() for r in results]):
         sys.exit(1)
 
 

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -25,8 +25,8 @@ logger = logging.getLogger('destral.cli')
 @click.option('--modules', '-m', multiple=True)
 @click.option('--tests', '-t', multiple=True)
 @click.option('--enable-coverage', type=click.BOOL, default=False, is_flag=True)
-@click.option('--report-coverage', type=click.STRING, default=False)
-@click.option('--report-junitxml', type=click.BOOL, default=False, is_flag=True)
+@click.option('--report-coverage', type=click.BOOL, default=False, is_flag=True)
+@click.option('--report-junitxml', type=click.STRING, nargs=1, default=False)
 @click.option('--dropdb/--no-dropdb', default=True)
 @click.option('--requirements/--no-requirements', default=True)
 def destral(modules, tests, enable_coverage=None, report_coverage=None,
@@ -127,10 +127,9 @@ def destral(modules, tests, enable_coverage=None, report_coverage=None,
             results.append(result.wasSuccessful())
     if report_junitxml:
         for result in results:
-            junit_suite = result.get('junit_suite', False)
-            if junit_suite:
+            if result.get('junit_suite', False):
                 with open(report_junitxml, 'a') as report_file:
-                    report_file.write(junit_suite.to_xml_string())
+                    report_file.write(result.to_xml_string())
     if report_coverage:
         coverage.report()
     if enable_coverage:

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -38,10 +38,6 @@ class JUnitXMLResult(unittest.result.TestResult):
 
     def printErrors(self):
         self.endedAt = time.time()
-        self.junit_suite = junit_xml.TestSuite(
-            name=self.modulename,
-            test_cases=self.ran_tests
-        )
 
     def startTest(self, test):
         self._time_tests.append({
@@ -91,16 +87,11 @@ class JUnitXMLResult(unittest.result.TestResult):
     def addSkip(self, test, reason):
         self._end_test(test, type='Skip', out_data=reason)
 
-    def get_test_suites(self):
-        return self.junit_suite
-
-    def to_xml_string(self, test_suites=False):
-        if not test_suites:
-            test_suites = []
-        if self.junit_suite not in test_suites:
-            test_suites.append(self.junit_suite)
-        return junit_xml.TestSuite.to_xml_string(test_suites)
-
+    def get_test_suite(self, module_name):
+        return junit_xml.TestSuite(
+            name=module_name,
+            test_cases=self.ran_tests
+        )
 
 # MAMBA JUNITXML
 
@@ -218,6 +209,6 @@ class JUnitXMLMambaFormatter(formatters.Formatter):
             for test in self.junitxml_tests[testgroup]['tests']:
                 all_tests.append(test)
         return junit_xml.TestSuite(
-            name='{}/{}'.format('mamba', self.modulename),
+            name='{}.{}'.format('mamba', self.modulename),
             test_cases=all_tests
         )

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -136,9 +136,9 @@ class JUnitXMLMambaReporter(reporter.Reporter):
     def create_report_suites(self):
         suites = []
         for listener in self.listeners:
-            suites += listener.summary(
+            suites.append(listener.summary(
                 self.duration, self.example_count,
-                self.failed_count, self.pending_count)
+                self.failed_count, self.pending_count))
         return suites
 
 
@@ -216,11 +216,11 @@ class JUnitXMLMambaFormatter(formatters.Formatter):
         )
 
     def summary(self, duration, example_count, failed_count, pending_count):
-        self.junitxml_suites = [
-            junit_xml.TestSuite(
-                name=self.modulename or 'mamba',
-                test_cases=self.junitxml_tests[testgroup]['tests']
-            )
-            for testgroup in self.junitxml_tests.keys()
-        ]
-        return self.junitxml_suites
+        all_tests = []
+        for testgroup in self.junitxml_tests.keys():
+            for test in self.junitxml_tests[testgroup]:
+                all_tests.append(self.junitxml_tests[testgroup][test])
+        return junit_xml.TestSuite(
+            name='{}/{}'.format('mamba', self.modulename),
+            test_cases=all_tests
+        )

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -78,5 +78,11 @@ class JUnitXMLResult(unittest.result.TestResult):
 class LoggerStream(object):
     @staticmethod
     def write(text):
-        logger = logging.getLogger('destral.testing')
-        logger.error(text)
+        if text == '\n':
+            text = ''
+        logger = logging.getLogger('destral.testing.results')
+        logger.info(text)
+
+    @staticmethod
+    def flush():
+        pass

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -202,7 +202,7 @@ class JUnitXMLMambaFormatter(formatters.Formatter):
         self.current_group = self.junitxml_tests[example_group.name].get(
             'pre_group', False) or 'Total'
         self._end_test(
-            example_group, out_msg='End Group',
+            example_group, out_msg='Passed Group',
             last=self.junitxml_tests[example_group.name]['startedAt']
         )
 

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -7,6 +7,22 @@ from mamba import formatters
 from mamba import reporter
 from mamba.application_factory import ApplicationFactory
 
+# UNITTEST JUNITXML
+
+
+class LoggerStream(object):
+
+    @staticmethod
+    def write(text):
+        if text == '\n':
+            text = ''
+        logger = logging.getLogger('destral.testing.results')
+        logger.info(text)
+
+    @staticmethod
+    def flush():
+        pass
+
 
 class JUnitXMLResult(unittest.result.TestResult):
     def __init__(self, stream=None, descriptions=None, verbosity=None):
@@ -87,6 +103,9 @@ class JUnitXMLResult(unittest.result.TestResult):
         if self.junit_suite not in test_suites:
             test_suites.append(self.junit_suite)
         return junit_xml.TestSuite.to_xml_string(test_suites)
+
+
+# MAMBA JUNITXML
 
 
 class JUnitXMLApplicationFactory(ApplicationFactory):
@@ -205,17 +224,3 @@ class JUnitXMLMambaFormatter(formatters.Formatter):
             for testgroup in self.junitxml_tests.keys()
         ]
         return self.junitxml_suites
-
-
-class LoggerStream(object):
-
-    @staticmethod
-    def write(text):
-        if text == '\n':
-            text = ''
-        logger = logging.getLogger('destral.testing.results')
-        logger.info(text)
-
-    @staticmethod
-    def flush():
-        pass

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -218,8 +218,8 @@ class JUnitXMLMambaFormatter(formatters.Formatter):
     def summary(self, duration, example_count, failed_count, pending_count):
         all_tests = []
         for testgroup in self.junitxml_tests.keys():
-            for test in self.junitxml_tests[testgroup]:
-                all_tests.append(self.junitxml_tests[testgroup][test])
+            for test in self.junitxml_tests[testgroup]['tests']:
+                all_tests.append(test)
         return junit_xml.TestSuite(
             name='{}/{}'.format('mamba', self.modulename),
             test_cases=all_tests

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -30,7 +30,6 @@ class JUnitXMLResult(unittest.result.TestResult):
         self.junit_suite = False
         self.ran_tests = []
         self._time_tests = []
-        self.modulename = False
         self.startedAt = None
         self.endedAt = None
 
@@ -49,8 +48,6 @@ class JUnitXMLResult(unittest.result.TestResult):
             'start': time.time(),
             'end': False
         })
-        if not self.modulename:
-            self.modulename = str(test).split()[-1][1:-1]
         super(JUnitXMLResult, self).startTest(test)
 
     def _end_test(self, test, type='Success', err_data=None, out_data=''):
@@ -64,7 +61,7 @@ class JUnitXMLResult(unittest.result.TestResult):
         if not self._time_tests[test_index]['end']:
             self._time_tests[test_index]['end'] = endtime
         test_name = str(test).split()[0]
-        test_classname = self.modulename or 'destral'
+        test_classname = str(test).split()[-1][1:-1]
         err_text = ''
         if err_data:
             err_text = self._exc_info_to_string(err_data, test)

--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -1,0 +1,82 @@
+import unittest
+import junit_xml
+import time
+import logging
+
+
+class JUnitXMLResult(unittest.result.TestResult):
+    def __init__(self, stream=None, descriptions=None, verbosity=None):
+        super(JUnitXMLResult, self).__init__(stream, descriptions, verbosity)
+        self.junit_suite = False
+        self.ran_tests = []
+        self._time_tests = []
+        self.modulename = False
+        self.startedAt = None
+        self.endedAt = None
+
+    def startTestRun(self):
+        self.startedAt = time.time()
+
+    def printErrors(self):
+        self.endedAt = time.time()
+        self.junit_suite = junit_xml.TestSuite(
+            name=self.modulename,
+            test_cases=self.ran_tests
+        )
+
+    def startTest(self, test):
+        self._time_tests.append({
+            'start': time.time(),
+            'end': False
+        })
+        if not self.modulename:
+            self.modulename = str(test).split()[-1][1:-1]
+        super(JUnitXMLResult, self).startTest(test)
+
+    def _end_test(self, test, type='Success', err_data=None, out_data=''):
+        test_index = self.testsRun - 1
+        # If already ended, do nothing
+        if (len(self.ran_tests) == self.testsRun and
+                self.ran_tests[test_index]):
+            return
+        start_time = self._time_tests[test_index]['start']
+        endtime = self._time_tests[test_index]['end'] or time.time()
+        if not self._time_tests[test_index]['end']:
+            self._time_tests[test_index]['end'] = endtime
+        test_name = str(test).split()[0]
+        test_classname = self.modulename or 'destral'
+        err_text = ''
+        if err_data:
+            err_text = self._exc_info_to_string(err_data, test)
+        self.ran_tests.append(junit_xml.TestCase(
+            name=test_name,
+            classname=test_classname,
+            elapsed_sec=(endtime - start_time),
+            stdout=out_data,
+            stderr=err_text,
+            status=type
+        ))
+
+    def stopTest(self, test):
+        self._end_test(test, type='Stopped')
+        super(JUnitXMLResult, self).stopTest(test)
+
+    def addError(self, test, err):
+        self._end_test(test, err_data=err, type='Error')
+        super(JUnitXMLResult, self).addError(test, err)
+
+    def addFailure(self, test, err):
+        self._end_test(test, err_data=err, type='Error')
+
+    def addSuccess(self, test):
+        self._end_test(test)
+
+    def addSkip(self, test, reason):
+        self._end_test(test, type='Skip', out_data=reason)
+
+
+class LoggerStream(object):
+    @staticmethod
+    def write(text):
+        logger = logging.getLogger('destral.testing')
+        logger.error(text)

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -4,11 +4,12 @@ import os
 import unittest
 
 from destral.junitxml_testing import JUnitXMLResult, LoggerStream
+from destral.junitxml_testing import JUnitXMLApplicationFactory
+from destral.junitxml_testing import JUnitXMLMambaFormatter
 from destral.openerp import OpenERPService
 from destral.transaction import Transaction
 from destral.utils import module_exists
 from osconf import config_from_environment
-from mamba import application_factory
 
 
 logger = logging.getLogger('destral.testing')
@@ -323,18 +324,23 @@ def get_spec_suite(module):
     """
     spec_dir = os.path.join(module, 'spec')
     specs_dir = os.path.join(module, 'specs')
+    junitxml = config_from_environment(
+        'DESTRAL', ['verbose', 'junitxml'],
+        verbose=2, junitxml=False
+    ).get('junitxml', False)
     if os.path.exists(spec_dir) or os.path.exists(specs_dir):
         # Create a fake arguments object
         arguments = type('Arguments', (object, ), {})
         arguments.specs = [spec_dir, specs_dir]
         arguments.slow = 0.075
         arguments.enable_coverage = False
-        arguments.format = 'progress'
+        arguments.format = 'junitxml' if junitxml else 'progress'
         arguments.no_color = True
         arguments.watch = False
         arguments.coverage_file = '.coverage'
         arguments.tags = None
-        factory = application_factory.ApplicationFactory(arguments)
+        factory = JUnitXMLApplicationFactory(
+            arguments, modulename=module, junitxml_file=junitxml)
         logger.info('Mamba application factory created for specs: {0}'.format(
             spec_dir
         ))

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -339,6 +339,8 @@ def get_spec_suite(module):
         arguments.watch = False
         arguments.coverage_file = '.coverage'
         arguments.tags = None
+        if 'erp/server/bin' in module:
+            module = 'root_path'
         factory = JUnitXMLApplicationFactory(
             arguments, modulename=module, junitxml_file=junitxml)
         logger.info('Mamba application factory created for specs: {0}'.format(

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -3,6 +3,7 @@ import logging
 import os
 import unittest
 
+from destral.junitxml_testing import JUnitXMLResult, LoggerStream
 from destral.openerp import OpenERPService
 from destral.transaction import Transaction
 from destral.utils import module_exists
@@ -302,7 +303,16 @@ def run_unittest_suite(suite):
     """Run test suite
     """
     logger.info('Running test suit: {0}'.format(suite))
-    return unittest.TextTestRunner(verbosity=2).run(suite)
+    confs = config_from_environment(
+        'DESTRAL', ['verbose', 'junitxml'],
+        verbose=2, junitxml=False
+    )
+    verbose = confs.get('verbose', 2)
+    junitxml = confs.get('junitxml', False)
+    result = JUnitXMLResult if junitxml else unittest.TextTestResult
+    return unittest.TextTestRunner(
+        verbosity=verbose, resultclass=result, stream=LoggerStream
+    ).run(suite)
 
 
 def get_spec_suite(module):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
         'mamba',
         'coverage',
         'python-dateutil',
-        'babel>=2.4.0'
+        'babel>=2.4.0',
+        'junit_xml'
     ],
     license='GNU GPLv3',
     author='GISCE-TI, S.L.',


### PR DESCRIPTION
Closes #96 

Adds:

- [x] JUnitXML report export (`--report_junitxml <filepath>`)
- [x] JUnitXML Result Handler for Unittest Testing
→ Maybe we can export it to an open source repository for the community?
- [x] JUnitXML Result Handler for Spec Testing