### PR TITLE
Add super calls to correctly register results

### DIFF
--- a/destral/junitxml_testing.py
+++ b/destral/junitxml_testing.py
@@ -94,12 +94,15 @@ class JUnitXMLResult(unittest.result.TestResult):
 
     def addFailure(self, test, err):
         self._end_test(test, err_data=err, type='Failure')
+        super(JUnitXMLResult, self).addFailure(test, err)
 
     def addSuccess(self, test):
         self._end_test(test)
+        super(JUnitXMLResult, self).addSuccess(test)
 
     def addSkip(self, test, reason):
         self._end_test(test, type='Skip', out_data=reason)
+        super(JUnitXMLResult, self).addSkip(test, reason)
 
     def get_test_suite(self, module_name):
         return junit_xml.TestSuite(


### PR DESCRIPTION
Add missing super calls to correctly register results. Even though it registered the result on the JunitXML's Result class.

- Output on tests results wasn't submitted and/or registered for Destral's call

Affected results were:

- Failure
- Skip
- Success
