### PR TITLE
freeze mamba to 0.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'osconf',
         'expects',
         'click',
-        'mamba',
+        'mamba<=0.9.2',
         'coverage',
         'python-dateutil',
         'babel>=2.4.0',


### PR DESCRIPTION
mamba 0.9.3 changed interface for class ApplicationFactory and `create_runner` is no longer available. So we freeze the `setup.py` dependency to 0.9.2