### PR TITLE
TO MERGE: Add missing mock requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         'expects',
         'click',
         'mamba',
+        'mock',
         'coverage',
         'python-dateutil',
         'babel>=2.4.0',


### PR DESCRIPTION
Mock was not present in the requirement list.

Added `mock` on the `install_requires` of the `setup.py` file.