### PR TITLE
if named db not found, it creates it

### DIFF
--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -3,6 +3,7 @@ import time
 
 from osconf import config_from_environment
 from destral.utils import update_config
+import psycopg2
 
 
 logger = logging.getLogger('destral.openerp')
@@ -43,7 +44,7 @@ class OpenERPService(object):
         if 'db_name' in config:
             try:
                 self.db_name = config['db_name']
-            except Exception as e:
+            except psycopg2.OperationalError as e:
                 logger.info(
                     "Error opening named database '%s', creating it",
                     config['db_name'])

--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -41,16 +41,23 @@ class OpenERPService(object):
         self.db = None
         self.pool = None
         if 'db_name' in config:
-            self.db_name = config['db_name']
+            try:
+                self.db_name = config['db_name']
+            except Exception as e:
+                logger.info(
+                    "Error opening named database '%s', creating it",
+                    config['db_name'])
+                self.db_name = self.create_database(False, db_name=config['db_name'])
         # Stop the cron
         netsvc.Agent.quit()
 
-    def create_database(self, template=True):
+    def create_database(self, template=True, db_name=None):
         """Creates a new database.
 
         :param template: use a template (name must be `base`) (default True)
         """
-        db_name = 'test_' + str(int(time.time()))
+        if db_name is None:
+            db_name = 'test_' + str(int(time.time()))
         import sql_db
         conn = sql_db.db_connect('postgres')
         cursor = conn.cursor()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
         'coverage',
         'python-dateutil',
         'babel>=2.4.0',
-        'junit_xml'
+        'junit_xml',
+        'psycopg2',
     ],
     license='GNU GPLv3',
     author='GISCE-TI, S.L.',


### PR DESCRIPTION
If a db name is provided and it does not exist, create such database and populate it.

This feature enables a more agile workflow when developing. Just pick the same name (ie, testdb) for the database. The first test run it will be created, the next ones you will reuse it. If you need a rebuild because you changed data or data structure, just run 'dropdb testdb' and it will be rebuild on the next test run.

Existing workflow created a random name, although convenient for CI, while developing, you had to figure out the generated name and then set as envvar. Each time you need to rebuild the database, such name changes and you have to set it over and over.