### PR TITLE
Terminate connections form database before dropdb

### DIFF
--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -86,6 +86,13 @@ class OpenERPService(object):
         try:
             logger.info('Droping database %s', self.db_name)
             cursor.autocommit(True)
+            logger.info('Disconnect all sessions from database %s', self.db_name)
+            cursor.execute(
+                "SELECT pg_terminate_backend(pg_stat_activity.pid) "
+                " FROM pg_stat_activity "
+                " WHERE pg_stat_activity.datname = '{}'"
+                " AND pid <> pg_backend_pid() ".format(self.db_name)
+            )
             cursor.execute('DROP DATABASE ' + self.db_name)
         finally:
             cursor.close()


### PR DESCRIPTION
Before drop database try to close open connections to solve test problems like above example

``` bash
INFO:destral.openerp:Droping database test_1530099807
Traceback (most recent call last):
  File "/home/circleci/src/venv/bin/destral", line 11, in <module>
    sys.exit(destral())
  File "/home/circleci/src/venv/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/circleci/src/venv/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/circleci/src/venv/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/circleci/src/venv/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/circleci/src/venv/lib/python2.7/site-packages/destral/cli.py", line 131, in destral
    result = run_unittest_suite(suite)
  File "/home/circleci/src/venv/lib/python2.7/site-packages/destral/testing.py", line 316, in run_unittest_suite
    ).run(suite)
  File "/usr/local/lib/python2.7/unittest/runner.py", line 151, in run
    test(result)
  File "/usr/local/lib/python2.7/unittest/suite.py", line 70, in __call__
    return self.run(*args, **kwds)
  File "/home/circleci/src/venv/lib/python2.7/site-packages/destral/testing.py", line 60, in run
    self.openerp.drop_database()
  File "/home/circleci/src/venv/lib/python2.7/site-packages/destral/openerp.py", line 89, in drop_database
    cursor.execute('DROP DATABASE ' + self.db_name)
  File "/home/circleci/src/erp/server/bin/sql_db.py", line 85, in wrapper
    return f(self, *args, **kwargs)
  File "/home/circleci/src/erp/server/bin/sql_db.py", line 133, in execute
    res = self._obj.execute(query, params)
psycopg2.OperationalError: database "test_1530099807" is being accessed by other users
DETAIL:  There are 2 other sessions using the database.
```