### PR TITLE
Add new class OOTestWithCursor

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -90,6 +90,17 @@ class OOTestCase(unittest.TestCase):
         return self.openerp.db_name
 
 
+class OOTestCaseWithCursor(OOTestCase):
+
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor()
+        self.uid = self.txn.user
+
+    def tearDown(self):
+        self.txn.stop()
+
+
 class OOBaseTests(OOTestCase):
 
     def test_all_views(self):

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -54,7 +54,7 @@ Variables definition
   The langs to be used while checking the translations of each module. This variable
   is mandatory as it should always be provided.
   The langs provided must always be in a Python formated list, such as:
-    `export DESTRAL_TESTING_LANGS = ['en_US']`
+  `export DESTRAL_TESTING_LANGS = ['en_US']`
 
 Configuring OpenERP
 ===================

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -1,0 +1,35 @@
+How to write a test
+===================
+
+Unittesting
+-----------
+
+Destral checks for a module called `tests` inside the module folder eg. `module/tests/__init__.py`.
+
+
+.. code-block:: python
+
+    from destral import testing
+    from destral.transaction import Transaction
+
+    class TestSimpleMethod(testing.OOTestCase):
+
+        def setUp(self):
+            self.txn = Transaction().start(self.database)
+            self.cursor = self.txn.cursor()
+            self.uid = self.txn.user
+
+        def tearDown(self):
+            self.txn.stop()
+
+        def test_check_hello_world_name(self):
+            obj = self.openerp.pool.get('our.object')
+            self.assertEqual(
+                obj.hello(self.cursor, self.uid, 'Pepito'),
+                'Hello World Pepito!'
+            )
+
+.. versionadded:: v1.4.0
+
+We can also use the `OOTestCaseWithCursor` class that already has the` setUp` and
+`tearDown` made.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Contents:
    :maxdepth: 2
 
    README.rst
+   how-to.rst
    api.rst
 
 


### PR DESCRIPTION
Add a new class which automatically have `setUp` and `tearDown` to have a transaction in every test:

```python
    def setUp(self):
        self.txn = Transaction().start(self.database)
        self.cursor = self.txn.cursor()
        self.uid = self.txn.user

    def tearDown(self):
        self.txn.stop()
```

We also add some documentation