### PR TITLE
Fix cursor getting on OOTestCaseWithCursor

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -94,7 +94,7 @@ class OOTestCaseWithCursor(OOTestCase):
 
     def setUp(self):
         self.txn = Transaction().start(self.database)
-        self.cursor = self.txn.cursor()
+        self.cursor = self.txn.cursor
         self.uid = self.txn.user
 
     def tearDown(self):


### PR DESCRIPTION
Getting the cursor from the transaction fails as it's a property and not a method.

Getting it without parenthesis should fix the problem