### PR TITLE
Improve test_access_rules tests

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -162,9 +162,12 @@ class OOBaseTests(OOTestCase):
                         ('model_id.id', '=', model_id)
                     ])
                     if not access_ids:
-                        no_access.append(
-                            '.'.join(imd.name.split('_')[1:])
-                        )
+                        if '.test' in imd.name:
+                            continue
+                        else:
+                            no_access.append(
+                                '.'.join(imd.name.split('_')[1:])
+                            )
 
         if no_access:
             self.fail(

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -1,5 +1,5 @@
-# coding=utf-8
 from __future__ import absolute_import
+# coding=utf-8
 
 
 from destral.utils import find_files, compare_pofiles


### PR DESCRIPTION
# Objective
- Avoid check for access_rules on classes created for testing.
 # Problem
- Sometimes, dummy classes for test are created to test some functionalities. Then, the test `test_access_rules` check if those classes have the access rules defined and they not. 

# Solution
- All those test classes have on common that they have on their names `XXXX.test`. By checking if the name of the class contains the substring `.test` we can avoid check for access rules on those models.
