### PR TITLE
Improve error message for module not found

### DIFF
--- a/destral/utils.py
+++ b/destral/utils.py
@@ -93,7 +93,7 @@ def get_dependencies(module, addons_path=None, deps=None):
     pj = os.path.join
     module_path = pj(addons_path, module)
     if not os.path.exists(module_path):
-        raise Exception('Module {} not found in {}'.format(
+        raise Exception('Module \'{}\' not found in {}'.format(
             module, addons_path
         ))
     terp_path = pj(module_path, '__terp__.py')


### PR DESCRIPTION
This will improve the detection of a bad typed module name as the comma mark the real form of the module name set on TERP. 

For an example, if you add an extra space after a module name on TERP, this will help to detect that the deps. is bad typed. 

