### PR TITLE
Add Pylint support

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -8,6 +8,7 @@ import click
 from destral.utils import *
 from destral.testing import run_unittest_suite, get_unittest_suite
 from destral.testing import run_spec_suite, get_spec_suite
+from destral.linter import run_linter
 from destral.openerp import OpenERPService
 from destral.patch import RestorePatchedRegisterAll
 from destral.cover import OOCoverage
@@ -30,9 +31,11 @@ logger = logging.getLogger('destral.cli')
 @click.option('--report-junitxml', type=click.STRING, nargs=1, default=False)
 @click.option('--dropdb/--no-dropdb', default=True)
 @click.option('--requirements/--no-requirements', default=True)
+@click.option('--enable-lint', type=click.BOOL, default=False, is_flag=True)
 def destral(modules, tests, all_tests=None, enable_coverage=None,
             report_coverage=None, report_junitxml=None, dropdb=None,
-            requirements=None):
+            requirements=None, **kwargs):
+    enable_lint = kwargs.pop('enable_lint')
     sys.argv = sys.argv[:1]
     service = OpenERPService()
     if report_junitxml:
@@ -157,6 +160,11 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
         coverage.report()
     if enable_coverage:
         coverage.save()
+
+    if enable_lint:
+        modules_path = ['{}/{}'.format(addons_path, m) for m in modules_to_test]
+        if modules_path:
+            run_linter(modules_path)
 
     if not all(results):
         sys.exit(1)

--- a/destral/linter.py
+++ b/destral/linter.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+import logging
+
+from pylint.reporters.text import ColorizedTextReporter
+from pylint.lint import PyLinter
+from pylint.config import find_pylintrc
+
+
+logger = logging.getLogger(__name__)
+
+
+def run_linter(files=None):
+    if files is None:
+        return
+    logger.info('Linting {}'.format(', '.join(files)))
+    rep = ColorizedTextReporter()
+    linter = PyLinter(reporter=rep, pylintrc=find_pylintrc())
+    linter.load_default_plugins()
+    linter.disable('I')
+    linter.enable('c-extension-no-member')
+    linter.read_config_file()
+    linter.load_config_file()
+    linter.check(files)
+    linter.generate_reports()

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         'click',
         'mamba>=0.9.3',
         'coverage',
+        'pylint',
         'python-dateutil',
         'babel>=2.4.0',
         'junit_xml',


### PR DESCRIPTION
Instead of #62 which runs the pylint we integrated it as a library.

It will use the `.pylintrc` file if is found

Closes #62 