### PR TITLE
Sólo añadir dependencias si no están en la lista

### DIFF
--- a/destral/utils.py
+++ b/destral/utils.py
@@ -107,8 +107,9 @@ def get_dependencies(module, addons_path=None, deps=None):
         terp = literal_eval(terp_file.read())
 
     for dep in terp['depends']:
-        deps.append(dep)
-        deps += get_dependencies(dep, addons_path, deps)
+        if dep not in deps:
+            deps.append(dep)
+            deps += get_dependencies(dep, addons_path, deps)
 
     return list(set(deps))
 


### PR DESCRIPTION
Hemos encontrado un caso donde la recursión de búsqueda de dependencias se hace infinita. Con este *fix* se soluciona que solo añade si los módulos no están ya en la lista de dependencias