### PR TITLE
Fix import urllib working with py2 and py3

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -2,7 +2,7 @@ import os
 import sys
 import subprocess
 import logging
-from six.moves import urllib as urllib2
+from six.moves.urllib import request as urllib2
 
 import click
 from destral.utils import *


### PR DESCRIPTION
Fix support for working urllib in both py2 and py3.

In python3 `Request` use `urllib.request.Request`, in python 2.x use directly `urllib.Request`

