### PR TITLE
FIX ISSUE: Multi-module test crashes

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -46,6 +46,12 @@ class OOTestSuite(unittest.TestSuite):
                     self.config['use_template']
                 )
             else:
+                # In order to install a module, we need to ensure that the
+                # db and the pool attributes of the openerp object are set.
+                if self.openerp.db is None:
+                    self.openerp.db = self.openerp.pooler.get_db(self.openerp.db_name)
+                if self.openerp.pool is None:
+                    self.openerp.pool = self.openerp.pooler.get_pool(self.openerp.db_name)
                 self.drop_database = False
             result.db_name = self.openerp.db_name
             self.openerp.install_module(self.config['module'])


### PR DESCRIPTION
# Error description

Execution crashes when running destral with two modules. It crashes when installing the second module.

# Causes

Installing a new module requires that the `db` and `pool` attributes of the `OpenERPService` object are set. When installing the second module, those attributes are `None`.

# Fix

Before installing a module, check if the required `OpenERPService` object attributes are set.