### PR TITLE
Testear inher views in free time

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -139,23 +139,36 @@ class OOBaseTests(OOTestCase):
                                           view.type)
                     if view.inherit_id:
                         while view.inherit_id:
+                            try:
+                                # print view.read([])
+                                # inh = imd_obj.read(
+                                #     txn.cursor, txn.user, view.id
+                                # )
+
+                                model.fields_view_get(
+                                    txn.cursor, txn.user, view.id, view.type
+                                )
+                            except IndexError as ie:
+                                err_mn = '{}.{}'.format(view.origin_module.name, view.name)
+                                raise Exception(
+                                    'Inherit View (xml id: %s) references model %s '
+                                    'which does '
+                                    'not exist' % (
+                                        err_mn, view.model
+                                    )
+                                )
+                            logger.info(
+                                'Testing inherit view %s (id: %s)',
+                                view.name, view.id
+                            )
                             view = view.inherit_id
-                            if not view.inherit_id:
-                                model.fields_view_get(
-                                    txn.cursor, txn.user, view.id, view.type
-                                )
-                                logger.info(
-                                    'Testing main view %s (id: %s)',
-                                    view.name, view.id
-                                )
-                            else:
-                                model.fields_view_get(
-                                    txn.cursor, txn.user, view.id, view.type
-                                )
-                                logger.info(
-                                    'Testing inherit view %s (id: %s)',
-                                    view.name, view.id
-                                )
+                        model.fields_view_get(
+                            txn.cursor, txn.user, view.id, view.type
+                        )
+                        logger.info(
+                            'Testing main view %s (id: %s)',
+                            view.name, view.id
+                        )
 
     def test_access_rules(self):
         """Test access rules for all the models created in the module

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -140,21 +140,18 @@ class OOBaseTests(OOTestCase):
                     if view.inherit_id:
                         while view.inherit_id:
                             try:
-                                # print view.read([])
-                                # inh = imd_obj.read(
-                                #     txn.cursor, txn.user, view.id
-                                # )
-
+                                print view.read([])
                                 model.fields_view_get(
                                     txn.cursor, txn.user, view.id, view.type
                                 )
                             except IndexError as ie:
                                 err_mn = '{}.{}'.format(view.origin_module.name, view.name)
                                 raise Exception(
-                                    'Inherit View (xml id: %s) references model %s '
-                                    'which does '
-                                    'not exist' % (
-                                        err_mn, view.model
+                                    'Inherit View (xml id: %s) '
+                                    'references model %s '
+                                    'has non-existent field '
+                                    'in model %s' % (
+                                        err_mn, view.model, view.model
                                     )
                                 )
                             logger.info(

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -140,20 +140,11 @@ class OOBaseTests(OOTestCase):
                     if view.inherit_id:
                         while view.inherit_id:
                             try:
-                                print view.read([])
                                 model.fields_view_get(
                                     txn.cursor, txn.user, view.id, view.type
                                 )
-                            except IndexError as ie:
-                                err_mn = '{}.{}'.format(view.origin_module.name, view.name)
-                                raise Exception(
-                                    'Inherit View (xml id: %s) '
-                                    'references model %s '
-                                    'has non-existent field '
-                                    'in model %s' % (
-                                        err_mn, view.model, view.model
-                                    )
-                                )
+                            except ReferenceError as r_err:
+                                raise r_err
                             logger.info(
                                 'Testing inherit view %s (id: %s)',
                                 view.name, view.id

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -140,10 +140,22 @@ class OOBaseTests(OOTestCase):
                     if view.inherit_id:
                         while view.inherit_id:
                             view = view.inherit_id
-                        model.fields_view_get(txn.cursor, txn.user, view.id,
-                                              view.type)
-                        logger.info('Testing main view %s (id: %s)',
-                                    view.name, view.id)
+                            if not view.inherit_id:
+                                model.fields_view_get(
+                                    txn.cursor, txn.user, view.id, view.type
+                                )
+                                logger.info(
+                                    'Testing main view %s (id: %s)',
+                                    view.name, view.id
+                                )
+                            else:
+                                model.fields_view_get(
+                                    txn.cursor, txn.user, view.id, view.type
+                                )
+                                logger.info(
+                                    'Testing inherit view %s (id: %s)',
+                                    view.name, view.id
+                                )
 
     def test_access_rules(self):
         """Test access rules for all the models created in the module


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15796004/84507829-b5face80-acc1-11ea-92c0-b651b6e6b3ef.png)


Se ha detectado un caso particular en que el test `test_all_views` pasaba, aun sin existir el campo en el modelo indicado en la posicion de la flecha.
(estava definido en otro modelo)

## Comportamiento Nuevo

- Salta el test para las inher views

![image](https://user-images.githubusercontent.com/15796004/84509121-91075b00-acc3-11ea-912c-eab1fb1ee1ae.png)


Estare unos dias testeando cambios aprobechando cuando tenga que pasar tests