### PR TITLE
Subprocess compatibility py2 & py3

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -74,7 +74,7 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
         else:
             paths = subprocess.check_output([
                 "git", "diff", "--name-only", "HEAD~1..HEAD"
-            ])
+            ]).decode('utf-8')
             paths = [x for x in paths.split('\n') if x]
             logger.info('Files from last commit: {}'.format(
                 ', '.join(paths)


### PR DESCRIPTION
#### In python2 `subprocess.check_output` return a `str obj`:
```python
>>> import subprocess
>>> type(subprocess.check_output(["git", "diff", "--name-only", "HEAD~1..HEAD"]))
<type 'str'>
```

#### In python3 `subprocess.check_output` return a `bytes obj`:
```python
>>> import subprocess
>>> type(subprocess.check_output(["git", "diff", "--name-only", "HEAD~1..HEAD"]))
<class 'bytes'>
```