### PR TITLE
Disable DB_CURSOR_EXECUTE on create cursor

### DIFF
--- a/destral/transaction.py
+++ b/destral/transaction.py
@@ -3,6 +3,7 @@ import six
 
 
 from destral.openerp import OpenERPService
+from signals import DB_CURSOR_EXECUTE
 
 
 class Singleton(type):
@@ -47,7 +48,12 @@ class Transaction(local):
         self.pool = self.service.pool
         self.cursor = self.service.db.cursor()
         self.user = user
-        self.context = context if context is not None else self.get_context()
+        try:
+            receivers = DB_CURSOR_EXECUTE.receivers
+            DB_CURSOR_EXECUTE.receivers = {}
+            self.context = context if context is not None else self.get_context()
+        finally:
+            DB_CURSOR_EXECUTE.receivers = receivers
         return self
 
     def stop(self):


### PR DESCRIPTION
To avoid tests failing due when creating a cursor the `user_obj.get_context()` is called, all cursors are marked as executed and tests transactions are failing