### PR TITLE
Evitar que lanze errores de parametros al usar PatchNewCursors con metodos que tengan cursores con parametros

### DIFF
--- a/destral/patch.py
+++ b/destral/patch.py
@@ -57,7 +57,7 @@ class PatchedConnection(object):
     def __getattr__(self, item):
         return getattr(self._connection, item)
 
-    def cursor(self, serialized=False):
+    def cursor(self, serialized=False, *args, **kwargs):
         """Wrapped function to return the same cursor
         """
         return self._cursor


### PR DESCRIPTION
Al testear metodos con el cursor parcheado y que los cursores internos se contruieran con parametros extra como el nivel de isolación o readonly lanzava un error ya que no estava adaptado para permitirlos
https://github.com/gisce/erp/pull/14977