### PR TITLE
Calling signal SHUTDOWN_REQUEST before exiting

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -169,8 +169,11 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
         if modules_path:
             run_linter(modules_path)
 
+    return_code = 0
     if not all(results):
-        sys.exit(1)
+        return_code = 1
+    service.shutdown()
+    sys.exit(return_code)
 
 
 if __name__ == '__main__':

--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -173,3 +173,10 @@ class OpenERPService(object):
                 logger.info(
                     'User admin enabled with password: %s on %s',
                     password, txn.cursor.dbname)
+
+    def shutdown(self):
+        try:
+            from signals import SHUTDOWN_REQUEST
+            SHUTDOWN_REQUEST.send(None)
+        except ImportError:
+            pass


### PR DESCRIPTION
Kill threads before exiting, this was found when the pubsub thread was introduced https://github.com/gisce/erp/pull/15492