### PR TITLE
Deep stop service on transaction unexpected error

### DIFF
--- a/destral/transaction.py
+++ b/destral/transaction.py
@@ -59,7 +59,8 @@ class Transaction(local):
     def stop(self):
         """Stop the transaction.
         """
-        self.cursor.close()
+        if self.cursor is not None:
+            self.cursor.close()
         self.service = None
         self.cursor = None
         self.user = None
@@ -81,10 +82,16 @@ class Transaction(local):
     def __exit__(self, type, value, traceback):
         self.stop()
 
-    def _assert_stopped(self):
-        assert self.service is None
-        assert self.database is None
-        assert self.cursor is None
-        assert self.pool is None
-        assert self.user is None
-        assert self.context is None
+    def _assert_stopped(self, deep=False):
+        try:
+            assert self.service is None
+            assert self.database is None
+            assert self.cursor is None
+            assert self.pool is None
+            assert self.user is None
+            assert self.context is None
+        except AssertionError as ae:
+            if not deep:
+                self.stop()
+                return self._assert_stopped(True)
+            raise ae


### PR DESCRIPTION
- Fix: Infinite thread on Transaction unexpected error
- Feature: Service assertion error does not interrupt execution (Stops and renew service for new test)
El error ocurria en un test que no era el culpable del error, el culpable era el test anterior ejecutado, tampoco se tenia traza del error ocurrido
- Feature: Error before assertion service none error is properly prompted on corresponding test