### PR TITLE
Add env var to know if erp is running from destral

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,2 @@
+[bumpversion]
+current_version = 1.12.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: DESTRAL_RELEASE
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 2.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: '2.7'
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+        with:
+          strip_v: false
+      - name: Creating a realease/pre-release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{steps.tag.outputs.tag}}
+          draft: false
+          prerelease: ${{ contains(github.ref, '-rc') }}
+          generate_release_notes: true
+      - name: Publish a Python distribution to PyPI
+        if: ${{ contains(github.ref, '-rc') }} == false
+        uses: conchylicultor/pypi-build-publish@v1
+        with:
+          pypi-token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,60 @@
+name: GISCE_DESTRAL_VERION
+on:
+  push:
+    branches: [ master ]
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Setup git
+        run: |
+          git config --global user.email "devel@gisce.net"
+          git config --global user.name "giscegit"
+      - name: Install python packages
+        run: |
+          pip install bump2version
+          pip install giscemultitools
+      - name: Get PR info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_GIT_TOKEN }}
+          WORKSPACE: ${{github.workspace}}
+        run: |
+          echo 'PR_INFO<<EOF' >> $GITHUB_ENV
+          gisce_github get-commits-sha-from-merge-commit --owner gisce --repository destral --sha $GITHUB_SHA >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Retrive info
+        run: |
+          eval `ssh-agent -s`
+          ssh-add - <<< '${{ secrets.SSH_PRIVATE }}'
+          pr_labels=$( echo '${{ env.PR_INFO }}' | jq -r '.pullRequest.labels' )
+          is_minor=false
+          is_major=false
+          is_patch=false
+          for label in echo $( echo $pr_labels | jq -r '.[].name' ); do
+            if [[ $label == 'minor' ]]; then
+              is_minor=true
+            elif [[ $label == 'major' ]]; then
+              is_major=true
+            elif [[ $label == 'patch' ]]; then
+              is_patch=true
+            fi
+          done
+          VERSION_TYPE=false
+          if [[ $is_major == true ]]; then
+            VERSION_TYPE="major"
+          elif [[ $is_minor == true ]]; then
+            VERSION_TYPE="minor"
+          elif [[ $is_patch == true ]]; then
+            VERSION_TYPE="patch"
+          fi
+          if [[ $VERSION_TYPE != false ]]; then
+            bump2version $VERSION_TYPE --tag --commit -m "Bump to v{new_version}" setup.py
+            git push origin master --tags
+          fi

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -36,6 +36,7 @@ logger = logging.getLogger('destral.cli')
 def destral(modules, tests, all_tests=None, enable_coverage=None,
             report_coverage=None, report_junitxml=None, dropdb=None,
             requirements=None, **kwargs):
+    os.environ['OPENERP_DESTRAL_MODE'] = "1"
     enable_lint = kwargs.pop('enable_lint')
     database = kwargs.pop('database')
     if database:


### PR DESCRIPTION
if OPENERP_DESTRAL_MODE is set it up, we now erp is running from destral, then we can raise some specific errors or change behavior.

For example we can raise errors on tests that on the contrary would only be logged in.

```diff
diff --git a/server/bin/osv/orm.py b/server/bin/osv/orm.py
index 8272d594f7a..84f55853754 100644
--- a/server/bin/osv/orm.py
+++ b/server/bin/osv/orm.py
@@ -238,6 +238,11 @@ class browse_record(object):
             else:
                 logger = netsvc.Logger()
                 logger.notifyChannel('orm', netsvc.LOG_ERROR, "Programming error: field '%s' does not exist in object '%s' !" % (name, self._table._name))
+                import os
+                if int(os.environ.get('OPENERP_DESTRAL_MODE', "0")):
+                    raise AttributeError(
+                        "Programming error: field '%s' does not exist in object '%s' !" % (name, self._table._name)
+                    )
                 return False
 
             # if the field is a classic one or a many2one, we'll fetch all

```