### PR TITLE
Option to add a constraint file to lock package versions to test

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -33,11 +33,13 @@ logger = logging.getLogger('destral.cli')
 @click.option('--dropdb/--no-dropdb', default=True)
 @click.option('--requirements/--no-requirements', default=True)
 @click.option('--enable-lint', type=click.BOOL, default=False, is_flag=True)
+@click.option('--constraints-file', type=click.STRING, nargs=1, default="")
 def destral(modules, tests, all_tests=None, enable_coverage=None,
             report_coverage=None, report_junitxml=None, dropdb=None,
             requirements=None, **kwargs):
     os.environ['OPENERP_DESTRAL_MODE'] = "1"
     enable_lint = kwargs.pop('enable_lint')
+    constraints_file = kwargs.pop('constraints_file')
     database = kwargs.pop('database')
     if database:
         os.environ['OPENERP_DB_NAME'] = database
@@ -126,7 +128,7 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
     for module in modules_to_test:
         with RestorePatchedRegisterAll():
             if requirements:
-                install_requirements(module, addons_path)
+                install_requirements(module, addons_path, constraints_file=constraints_file)
             spec_suite = get_spec_suite(os.path.join(addons_path, module))
             if spec_suite:
                 logger.info('Spec testing module %s', module)

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -125,7 +125,7 @@ def find_files(diff):
     return list(set(paths))
 
 
-def install_requirements(module, addons_path):
+def install_requirements(module, addons_path, constraints_file=''):
     """Install module requirements and its dependecies
     """
     pip = os.path.join(sys.prefix, 'bin', 'pip')
@@ -142,7 +142,10 @@ def install_requirements(module, addons_path):
             for req in requirements_files:
                 if os.path.exists(req):
                     logger.info('Requirements file %s found. Installing...', req)
-                    subprocess.check_call([pip, "install", "-r", req])
+                    if constraints_file:
+                        subprocess.check_call([pip, "install", "-c", constraints_file, "-r", req])
+                    else:
+                        subprocess.check_call([pip, "install", "-r", req])
 
 
 def coverage_modules_path(modules_to_test, addons_path):


### PR DESCRIPTION
How to use:

`--constraints-file /home/.../constraints.txt`

Example file:
```
pymongo==3.13.0
```
