### PR TITLE
Fix PatchNewCursor if created cursors use context __enter__ /__exit__

### DIFF
--- a/destral/patch.py
+++ b/destral/patch.py
@@ -39,6 +39,12 @@ class PatchedCursor(object):
     def __getattr__(self, item):
         return getattr(self.cursor, item)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return
+
 
 class PatchedConnection(object):
     """Patched connection wapper to return the same cursor.


### PR DESCRIPTION
Poder usar PatchNewCursors con codigo que crea y usa nuevos cursores con el `with`

```python
class TestPatchedCursors(testing.OOTestCase):
    def test_multiple_contexts(self):
        def magic(cursor, uid):
            import pooler
            with pooler.get_db_only(self.database).cursor() as _cr:
                pass
        user_obj = self.openerp.pool.get('res.users')
        setattr(user_obj, 'magic', magic)
        with Transaction().start(self.database) as txn:
            cursor = txn.cursor
            uid = txn.user
            with PatchNewCursors():
                user_obj.magic(cursor, uid)
```

```
2023-11-24 09:13:59,280:INFO:destral.testing.results:Traceback (most recent call last):
  File "/home/psala/Projects/erp/server/bin/addons/base/tests/__init__.py", line 47, in test_multiple_contexts
    user_obj.magic(cursor, uid)
  File "/home/psala/Projects/erp/server/bin/addons/base/tests/__init__.py", line 39, in magic
    with pooler.get_db_only(self.database).cursor() as _cr:
AttributeError: __exit__
```

