### PR TITLE
Controlar versión de `mamba` para asegurar compatibilidad con Python2 y Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,31 @@
+import sys
+
 from setuptools import setup, find_packages
 
-
+requirements = [
+    'requests',
+    'osconf',
+    'expects',
+    'six',
+    'click',
+    'coverage',
+    'lazy-object-proxy<1.7.0',
+    'pylint<=2.17.7',
+    'python-dateutil',
+    'babel>=2.4.0',
+    'junit_xml',
+    'psycopg2',
+]
+if sys.version_info.major < 3:
+    requirements.append('mamba<0.11.0')
+else:
+    requirements.append('mamba>=0.11.0')
 setup(
     name='destral',
     version='1.17.0',
     packages=find_packages(),
     url='https://github.com/gisce/destral',
-    install_requires=[
-        'requests',
-        'osconf',
-        'expects',
-        'six',
-        'click',
-        'mamba<0.11.0',
-        'coverage',
-        'lazy-object-proxy<1.7.0',
-        'pylint<=2.17.7',
-        'python-dateutil',
-        'babel>=2.4.0',
-        'junit_xml',
-        'psycopg2',
-    ],
+    install_requires=requirements,
     license='GNU GPLv3',
     author='GISCE-TI, S.L.',
     author_email='devel@gisce.net',


### PR DESCRIPTION
## Objetivos

- Hay que controlar la versión del paquete `mamba` para asegurar la compatibilidad tanto en Python 2 como en Python 3

## Relacionado
- https://github.com/gisce/erp/pull/19901