### PR TITLE
Skip View validation for redefined and controlled fields_get

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -120,6 +120,11 @@ class OOBaseTests(OOTestCase):
     def test_all_views(self):
         """Tests all views defined in the module.
         """
+        try:
+            from tools import TestingExceptions
+            SkipViewValidation = TestingExceptions.SkipViewValidation
+        except:
+            SkipViewValidation = False
         logger.info('Testing views for module %s', self.config['module'])
         imd_obj = self.openerp.pool.get('ir.model.data')
         view_obj = self.openerp.pool.get('ir.ui.view')
@@ -149,8 +154,13 @@ class OOBaseTests(OOTestCase):
                             'not exist' % (view_xml_name, view.model)
                         )
                     logger.info('Testing view %s (id: %s) v%s', view.name, view.id, view.version)
-                    model.fields_view_get(txn.cursor, txn.user, view.id,
-                                          view.type, version=view.version)
+                    if TestingExceptions:
+                        try:
+                            model.fields_view_get(txn.cursor, txn.user, view.id, view.type, version=view.version)
+                        except TestingExceptions.SkipViewValidation:
+                            continue
+                    else:
+                        model.fields_view_get(txn.cursor, txn.user, view.id, view.type, version=view.version)
                     if view.inherit_id:
                         version = view.version
                         while view.inherit_id:

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -154,7 +154,7 @@ class OOBaseTests(OOTestCase):
                             'not exist' % (view_xml_name, view.model)
                         )
                     logger.info('Testing view %s (id: %s) v%s', view.name, view.id, view.version)
-                    if TestingExceptions:
+                    if SkipViewValidation:
                         try:
                             model.fields_view_get(txn.cursor, txn.user, view.id, view.type, version=view.version)
                         except TestingExceptions.SkipViewValidation:


### PR DESCRIPTION
```
2024-07-03 15:31:22,027:INFO:destral.testing.results:ERROR: test_all_views (destral.testing.OOBaseTests)
Tests all views defined in the module.
2024-07-03 15:31:22,027:INFO:destral.testing.results:
2024-07-03 15:31:22,027:INFO:destral.testing.results:----------------------------------------------------------------------
2024-07-03 15:31:22,027:INFO:destral.testing.results:
2024-07-03 15:31:22,027:INFO:destral.testing.results:Traceback (most recent call last):
  File "/home/psala/Projects/destral/destral/testing.py", line 159, in test_all_views
    model.fields_view_get(txn.cursor, txn.user, view.id, view.type, version=view.version)
  File "/home/psala/Projects/erp/server/bin/addons/custom_search/custom_search.py", line 418, in fields_view_get
    view_id, view_type, context, toolbar, version)
  File "/home/psala/Projects/erp/server/bin/tools/misc.py", line 985, in wrapper
    result = func(*args, **kwargs)
  File "/home/psala/Projects/erp/server/bin/osv/orm.py", line 1922, in fields_view_get
    xarch, xfields = self.__view_look_dom_arch(cr, user, result['arch'], view_id, context=context)
  File "/home/psala/Projects/erp/server/bin/osv/orm.py", line 1626, in __view_look_dom_arch
    fields = self.fields_get(cr, user, fields_def.keys(), context)
  File "/home/psala/Projects/erp/server/bin/addons/custom_search/custom_search.py", line 382, in fields_get
    raise osv.except_osv(_('Error'), _('Search id not found'))
except_osv: warning -- Error

Search id not found
```