### PR TITLE
Allow extra module dependencies to be installed on tests

### DIFF
--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -145,10 +145,10 @@ class OpenERPService(object):
                     logger.info("Including extra dependencies:\n%s" % '\n'.join(extra_modules))
                     extra_modules_ids = module_obj.search(
                         txn.cursor, DEFAULT_USER,
-                        [('name', 'in', extra_modules)],
+                        [('name', 'in', extra_modules), ('state', '!=', 'installed')],
                     )
                     if len(extra_modules_ids) != len(extra_modules):
-                        logger.warning("Some extra dependencies were not found")
+                        logger.warning("Some extra dependencies were not found or already installed")
 
                     module_ids.extend(extra_modules_ids)
 

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -49,7 +49,7 @@ class OOTestSuite(unittest.TestSuite):
             else:
                 self.drop_database = False
             result.db_name = self.openerp.db_name
-            self.openerp.install_module(self.config['module'])
+            self.openerp.install_module(self.config['module'], with_test_depends=True)
         else:
             self.openerp.db_name = result.db_name
 


### PR DESCRIPTION
With the addition of the test_depends key in __terp__ files, the necessary modules are now pre-installed to run the tests efficiently.

```py
    "test_depends": [
        "giscedata_tarifas_cargos_20210601",
        "giscedata_tarifas_peajes_20160101",
        "giscedata_tarifas_peajes_20170101",
        "giscedata_tarifas_peajes_20180101",
        "giscedata_tarifas_peajes_20190101",
        "giscedata_tarifas_peajes_20200101",
        "giscedata_tarifas_peajes_20210601",
        "giscedata_tarifas_peajes_20220101",
        "giscedata_tarifas_pagos_capacidad_20170101",
        "giscedata_tarifas_pagos_capacidad_20190101",
        "giscedata_tarifas_pagos_capacidad_20210601"
    ],
```

This approach avoids redundant dependency installations during test execution, thus accelerating the runs by ensuring all modules are already available. This change centralizes dependency management, reducing the need to verify their presence repeatedly and optimizing overall test performance.