### PR TITLE
Add ws_info to context in tests

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -11,6 +11,8 @@ from destral.openerp import OpenERPService
 from destral.transaction import Transaction
 from destral.utils import module_exists
 from osconf import config_from_environment
+from ctx import _ws_info
+from tools.service_utils import WebserviceBase
 
 
 logger = logging.getLogger('destral.testing')
@@ -110,9 +112,11 @@ class OOTestCaseWithCursor(OOTestCase):
         self.txn = Transaction().start(self.database)
         self.cursor = self.txn.cursor
         self.uid = self.txn.user
+        _ws_info.push(WebserviceBase(uid=self.uid))
 
     def tearDown(self):
         self.txn.stop()
+        _ws_info.pop()
 
 
 class OOBaseTests(OOTestCase):


### PR DESCRIPTION
This pull request updates the `destral/testing.py` file to integrate web service context management into the test setup and teardown process. The changes ensure that a `WebserviceBase` instance is pushed to and popped from the `_ws_info` context stack during the test lifecycle.

### Integration of web service context management:

* **Imports added for context management**: Added imports for `_ws_info` from `ctx` and `WebserviceBase` from `tools.service_utils` to support the new web service context management functionality.
* **Test lifecycle updates**:
  - In `setUp(self)`: Added a line to push a `WebserviceBase` instance (initialized with `uid`) to the `_ws_info` context stack, ensuring the web service context is available during tests.
  - In `tearDown(self)`: Added a line to pop the `_ws_info` context stack, cleaning up the web service context after tests.