### PR TITLE
Allow use PatchNewCursors as a decorator

### DIFF
--- a/destral/patch.py
+++ b/destral/patch.py
@@ -93,6 +93,13 @@ class PatchNewCursors(object):
         current_session.db = PatchedConnection(current_session.db, current_cursor)
 
     def unpatch(self):
+        """
+        Restore the original database connection and cursor behavior.
+
+        This method undoes the changes made by the `patch` method by:
+        - Restoring the original `sql_db.db_connect` function.
+        - Reverting `current_session.db` to its original state.
+        """
         import sql_db
         logger.info('Unpatching creation of new cursors')
         sql_db.db_connect = self.orig

--- a/destral/patch.py
+++ b/destral/patch.py
@@ -114,6 +114,7 @@ class PatchNewCursors(object):
         return False
     def __call__(self, func):
         """Allow usage as a decorator"""
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             self.patch()
             try:

--- a/destral/patch.py
+++ b/destral/patch.py
@@ -1,4 +1,5 @@
 import logging
+from ctx import current_session, current_cursor
 
 
 logger = logging.getLogger(__name__)
@@ -88,11 +89,14 @@ class PatchNewCursors(object):
         logger.info('Patching creation of new cursors')
         self.orig = sql_db.db_connect
         sql_db.db_connect = PatchNewCursors.db_connect
+        self.orig_db = current_session.db
+        current_session.db = PatchedConnection(current_session.db, current_cursor)
 
     def unpatch(self):
         import sql_db
         logger.info('Unpatching creation of new cursors')
         sql_db.db_connect = self.orig
+        current_session.db = self.orig_db
 
     def __enter__(self):
         self.patch()

--- a/destral/patch.py
+++ b/destral/patch.py
@@ -1,4 +1,5 @@
 import logging
+import functools
 from ctx import current_session, current_cursor
 
 

--- a/destral/patch.py
+++ b/destral/patch.py
@@ -104,7 +104,7 @@ class PatchNewCursors(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.unpatch()
-
+        return False
     def __call__(self, func):
         """Allow usage as a decorator"""
         def wrapper(*args, **kwargs):

--- a/destral/patch.py
+++ b/destral/patch.py
@@ -86,6 +86,15 @@ class PatchNewCursors(object):
         return PatchedConnection(conn, cursor)
 
     def patch(self):
+        """
+        Patch the database connection to always return the same cursor.
+
+        This method replaces the `sql_db.db_connect` function with a custom
+        implementation that returns a `PatchedConnection`. It also updates
+        the current session's database connection to use the same patched
+        connection. This ensures that all new cursors created during the
+        session are consistent and tied to the same transaction.
+        """
         import sql_db
         logger.info('Patching creation of new cursors')
         self.orig = sql_db.db_connect


### PR DESCRIPTION
This pull request introduces enhancements to the `destral/patch.py` file, focusing on improving the patching mechanism for database connections. The changes include adding new imports, refactoring the patching logic, and enabling the patching functionality to be used as a decorator.

### Enhancements to patching mechanism:

* **New imports added**: Introduced `current_session` and `current_cursor` from `ctx` to manage the current database session and cursor during patching.
* **Refactored patching logic**: 
  - Added `patch` and `unpatch` methods to encapsulate the logic for modifying and restoring database connection behavior. 
  - Updated `__enter__` and `__exit__` methods to use the new patching methods, improving readability and maintainability.
* **Decorator functionality**: Added a `__call__` method to allow the patching mechanism to be used as a decorator, enabling easier integration with functions.

Now it can be used as:

```python
from destral.patch import PatchNewCursors


@PatchNewCursors()
def test_a_method(self):
    pass
```