### PR TITLE
feat: run installed module dependency tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ Key options:
 * ``--modules`` limits the run to specific addons.
 * ``--all-installed-tests`` installs the selected addon first and then runs
   tests for its dependency chain, from ``base`` up to the selected addon.
+  ``--installed-modules-tests`` is accepted as a backwards-compatible alias.
 * ``--enable-coverage`` / ``--report-coverage`` gather coverage metrics.
 * ``--report-junitxml`` writes suites under the given directory.
 * ``--requirements`` installs ``requirements*.txt`` for the addon and its

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ The ``destral`` CLI orchestrates module testing inside the ERP runtime:
 Key options:
 
 * ``--modules`` limits the run to specific addons.
+* ``--all-installed-tests`` installs the selected addon first and then runs
+  tests for its dependency chain, from ``base`` up to the selected addon.
 * ``--enable-coverage`` / ``--report-coverage`` gather coverage metrics.
 * ``--report-junitxml`` writes suites under the given directory.
 * ``--requirements`` installs ``requirements*.txt`` for the addon and its

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -26,6 +26,7 @@ logger = logging.getLogger('destral.cli')
 @click.option('--modules', '-m', multiple=True)
 @click.option('--tests', '-t', multiple=True)
 @click.option('--all-tests', '-a', type=click.BOOL, default=False, is_flag=True)
+@click.option('--all-installed-tests', type=click.BOOL, default=False, is_flag=True)
 @click.option('--enable-coverage', type=click.BOOL, default=False, is_flag=True)
 @click.option('--report-coverage', type=click.BOOL, default=False, is_flag=True)
 @click.option('--report-junitxml', type=click.STRING, nargs=1, default="")
@@ -46,7 +47,9 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
     constraints_file = kwargs.pop('constraints_file')
     coverage_html_report = kwargs.pop('coverage_html_report')
     database = kwargs.pop('database')
+    installed_modules_tests = kwargs.pop('installed_modules_tests')
     coverage_no_test_lines = kwargs.pop('coverage_without_test_lines')
+    initial_database = database or os.environ.get('OPENERP_DB_NAME')
     if database:
         os.environ['OPENERP_DB_NAME'] = database
     sys.argv = sys.argv[:1]
@@ -107,7 +110,10 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
     root_path = service.config['root_path']
 
     # Sort modules by dependencies
-    if modules_to_test:
+    modules_to_install = modules_to_test[:]
+    if installed_modules_tests and modules_to_test:
+        modules_to_test = get_modules_and_dependencies(modules_to_test, addons_path)
+    elif modules_to_test:
         modules_to_test = sort_modules_by_dependencies(modules_to_test, addons_path)
 
     if not modules_to_test:
@@ -128,6 +134,18 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
     coverage.enabled = (enable_coverage or report_coverage)
 
     junitxml_suites = []
+    created_database = False
+    installed_service = None
+    if installed_modules_tests and modules_to_install:
+        installed_service = OpenERPService()
+        if not installed_service.db_name:
+            installed_service.db_name = installed_service.create_database(False)
+            os.environ['OPENERP_DB_NAME'] = installed_service.db_name
+            created_database = True
+        for module in sort_modules_by_dependencies(modules_to_install, addons_path):
+            if requirements:
+                install_requirements(module, addons_path, constraints_file=constraints_file)
+            installed_service.install_module(module, with_test_depends=True)
 
     coverage.start()
     server_spec_suite = get_spec_suite(root_path)
@@ -142,7 +160,7 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
     logger.info('Modules to test: {}'.format(','.join(modules_to_test)))
     for module in modules_to_test:
         with RestorePatchedRegisterAll():
-            if requirements:
+            if requirements and not installed_modules_tests:
                 install_requirements(module, addons_path, constraints_file=constraints_file)
             spec_suite = get_spec_suite(os.path.join(addons_path, module))
             if spec_suite:
@@ -196,6 +214,12 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
     return_code = 0
     if not all(results):
         return_code = 1
+
+    if installed_service and created_database and dropdb:
+        installed_service.drop_database()
+        os.environ.pop('OPENERP_DB_NAME', None)
+    elif installed_service and not initial_database:
+        os.environ.pop('OPENERP_DB_NAME', None)
 
     service.shutdown(return_code)
     sys.exit(return_code)

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -146,9 +146,16 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
             installed_service.db_name = installed_service.create_database(False)
             os.environ['OPENERP_DB_NAME'] = installed_service.db_name
             created_database = True
+        modules_with_dependencies = get_modules_and_dependencies(
+            modules_to_install, addons_path
+        )
+        if requirements:
+            for module in modules_with_dependencies:
+                install_requirements(
+                    module, addons_path, constraints_file=constraints_file,
+                    include_dependencies=False
+                )
         for module in sort_modules_by_dependencies(modules_to_install, addons_path):
-            if requirements:
-                install_requirements(module, addons_path, constraints_file=constraints_file)
             installed_service.install_module(module, with_test_depends=True)
 
     coverage.start()
@@ -184,6 +191,7 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
                 logger.error('Suite not found: {}'.format(e))
                 service.shutdown(1)
             suite.drop_database = dropdb
+            suite.skip_module_install = bool(installed_modules_tests)
             suite.config['all_tests'] = all_tests
             if all_tests:
                 for m in get_dependencies(module, addons_path):

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -26,7 +26,11 @@ logger = logging.getLogger('destral.cli')
 @click.option('--modules', '-m', multiple=True)
 @click.option('--tests', '-t', multiple=True)
 @click.option('--all-tests', '-a', type=click.BOOL, default=False, is_flag=True)
-@click.option('--all-installed-tests', type=click.BOOL, default=False, is_flag=True)
+@click.option(
+    '--all-installed-tests', '--installed-modules-tests',
+    'installed_modules_tests', type=click.BOOL, default=False,
+    is_flag=True
+)
 @click.option('--enable-coverage', type=click.BOOL, default=False, is_flag=True)
 @click.option('--report-coverage', type=click.BOOL, default=False, is_flag=True)
 @click.option('--report-junitxml', type=click.STRING, nargs=1, default="")

--- a/destral/testing.py
+++ b/destral/testing.py
@@ -34,6 +34,7 @@ class OOTestSuite(unittest.TestSuite):
             ooconfig['update'].update({'base': 1})
         self.openerp = OpenERPService(**ooconfig)
         self.drop_database = True
+        self.skip_module_install = False
 
     def run(self, result, debug=False):
         """Run the test suite
@@ -51,7 +52,8 @@ class OOTestSuite(unittest.TestSuite):
             else:
                 self.drop_database = False
             result.db_name = self.openerp.db_name
-            self.openerp.install_module(self.config['module'], with_test_depends=True)
+            if not self.skip_module_install:
+                self.openerp.install_module(self.config['module'], with_test_depends=True)
         else:
             self.openerp.db_name = result.db_name
 

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -111,10 +111,10 @@ def get_dependencies(module, addons_path=None, deps=None):
 
     for dep in terp['depends']:
         if dep not in deps:
+            get_dependencies(dep, addons_path, deps)
             deps.append(dep)
-            deps += get_dependencies(dep, addons_path, deps)
 
-    return list(set(deps))
+    return deps
 
 
 def get_modules_and_dependencies(modules, addons_path):

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -14,6 +14,7 @@ __all__ = [
     'detect_module',
     'module_exists',
     'get_dependencies',
+    'get_modules_and_dependencies',
     'sort_modules_by_dependencies',
     'find_files',
     'install_requirements',
@@ -114,6 +115,23 @@ def get_dependencies(module, addons_path=None, deps=None):
             deps += get_dependencies(dep, addons_path, deps)
 
     return list(set(deps))
+
+
+def get_modules_and_dependencies(modules, addons_path):
+    """Get modules and all their dependencies sorted by dependency order.
+
+    :param modules: List of module names to expand
+    :param addons_path: Path to find the modules
+    :return: A list of dependencies and modules sorted by dependencies
+    """
+    modules_and_deps = []
+    for module in modules:
+        for dep in get_dependencies(module, addons_path):
+            if dep not in modules_and_deps:
+                modules_and_deps.append(dep)
+        if module not in modules_and_deps:
+            modules_and_deps.append(module)
+    return sort_modules_by_dependencies(modules_and_deps, addons_path)
 
 
 def sort_modules_by_dependencies(modules, addons_path):

--- a/destral/utils.py
+++ b/destral/utils.py
@@ -195,13 +195,17 @@ def find_files(diff):
     return list(set(paths))
 
 
-def install_requirements(module, addons_path, constraints_file=''):
-    """Install module requirements and its dependecies
+def install_requirements(
+        module, addons_path, constraints_file='', include_dependencies=True):
+    """Install module requirements and its dependencies
     """
     pip = os.path.join(sys.prefix, 'bin', 'pip')
     if os.path.exists(pip):
         logger = logging.getLogger('destral.utils')
-        modules_requirements = get_dependencies(module, addons_path)
+        if include_dependencies:
+            modules_requirements = get_dependencies(module, addons_path)
+        else:
+            modules_requirements = []
         modules_requirements.append(module)
         for module_requirements in modules_requirements:
             addons_path_module = os.path.join(addons_path, module_requirements)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,6 +136,20 @@ class SortModulesByDependenciesTests(unittest.TestCase):
         result = utils.sort_modules_by_dependencies([], self.addons_dir)
         self.assertEqual(result, [])
 
+    def test_get_modules_and_dependencies_single_module(self):
+        """Test expanding a module includes its dependencies in order"""
+        result = utils.get_modules_and_dependencies(
+            ['module_c'], self.addons_dir
+        )
+        self.assertEqual(result, ['base', 'module_a', 'module_b', 'module_c'])
+
+    def test_get_modules_and_dependencies_multiple_modules(self):
+        """Test expanding multiple modules deduplicates shared dependencies"""
+        result = utils.get_modules_and_dependencies(
+            ['module_b', 'module_c'], self.addons_dir
+        )
+        self.assertEqual(result, ['base', 'module_a', 'module_b', 'module_c'])
+
     def test_sort_modules_without_shared_dependencies(self):
         """Test sorting modules that don't depend on each other"""
         # Only include module_a and base (module_a depends on base)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,6 +136,11 @@ class SortModulesByDependenciesTests(unittest.TestCase):
         result = utils.sort_modules_by_dependencies([], self.addons_dir)
         self.assertEqual(result, [])
 
+    def test_get_dependencies_preserves_dependency_order(self):
+        """Test dependencies are returned in deterministic dependency order"""
+        result = utils.get_dependencies('module_c', self.addons_dir)
+        self.assertEqual(result, ['base', 'module_a', 'module_b'])
+
     def test_get_modules_and_dependencies_single_module(self):
         """Test expanding a module includes its dependencies in order"""
         result = utils.get_modules_and_dependencies(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,5 +164,64 @@ class SortModulesByDependenciesTests(unittest.TestCase):
         self.assertEqual(result, ['base', 'module_a'])
 
 
+class InstallRequirementsTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.old_prefix = utils.sys.prefix
+        self.old_check_call = utils.subprocess.check_call
+        self.old_get_dependencies = utils.get_dependencies
+        self.calls = []
+        bin_dir = os.path.join(self.tempdir, 'bin')
+        os.makedirs(bin_dir)
+        open(os.path.join(bin_dir, 'pip'), 'w').close()
+        utils.sys.prefix = self.tempdir
+        utils.subprocess.check_call = self.calls.append
+
+    def tearDown(self):
+        utils.get_dependencies = self.old_get_dependencies
+        utils.subprocess.check_call = self.old_check_call
+        utils.sys.prefix = self.old_prefix
+        shutil.rmtree(self.tempdir)
+
+    def _create_requirements(self, module):
+        module_dir = os.path.join(self.tempdir, 'addons', module)
+        os.makedirs(module_dir)
+        open(os.path.join(module_dir, 'requirements.txt'), 'w').close()
+        return module_dir
+
+    def test_install_requirements_can_skip_dependency_expansion(self):
+        addons_dir = os.path.join(self.tempdir, 'addons')
+        self._create_requirements('dep')
+        self._create_requirements('module_a')
+        utils.get_dependencies = lambda module, addons_path: ['dep']
+
+        utils.install_requirements(
+            'module_a', addons_dir, include_dependencies=False
+        )
+
+        self.assertEqual(len(self.calls), 1)
+        self.assertEqual(
+            self.calls[0][-1],
+            os.path.join(addons_dir, 'module_a', 'requirements.txt')
+        )
+
+    def test_install_requirements_keeps_dependency_expansion_by_default(self):
+        addons_dir = os.path.join(self.tempdir, 'addons')
+        self._create_requirements('dep')
+        self._create_requirements('module_a')
+        utils.get_dependencies = lambda module, addons_path: ['dep']
+
+        utils.install_requirements('module_a', addons_dir)
+
+        self.assertEqual(
+            [call[-1] for call in self.calls],
+            [
+                os.path.join(addons_dir, 'dep', 'requirements.txt'),
+                os.path.join(addons_dir, 'module_a', 'requirements.txt'),
+            ]
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Resumen

- Añade el parámetro `--all-installed-tests` al CLI de Destral.
- Con `-m <modulo> --all-installed-tests`, Destral instala primero el módulo indicado y después ejecuta los tests de toda su cadena de dependencias en orden, de `base` hasta el módulo objetivo.
- Reutiliza la misma base de datos ya instalada para ejecutar los tests de los módulos de la cadena, evitando reinstalar módulo a módulo durante la fase de test.
- Añade un helper para expandir módulos + dependencias y tests unitarios de orden/deduplicación.
- Documenta el nuevo parámetro en el README.

## Validación

- `git diff --check`
- `/home/openclaw/.pyenv/versions/erp2/bin/python -m unittest discover tests`
