### PR TITLE
Fix module_exists on Python 3.12

### DIFF
--- a/destral/utils.py
+++ b/destral/utils.py
@@ -1,5 +1,12 @@
 from ast import literal_eval
-import imp
+try:
+    from importlib import util as importlib_util
+except ImportError:
+    importlib_util = None
+if importlib_util is None:
+    import imp
+else:
+    imp = None
 import logging
 import os
 import re
@@ -50,30 +57,50 @@ def detect_module(path):
     return None
 
 
-def module_exists(module):
-    """Check if a python module exists.
+def _clear_netsvc_services():
+    try:
+        import netsvc
+    except ImportError:
+        return
+    netsvc.SERVICES.clear()
 
-    This is used to check if a module have its own tests defined, Eg:
-    `addons.module_name.tests`
-    
-    :param module: Module name to check
-    :return: True if exists or False if not
-    """
+
+def _module_exists_with_imp(module):
     modlist = module.split('.')
     pathlist = None
     for mod in modlist:
+        openfile = None
         try:
             openfile, pathname, desc = imp.find_module(mod, pathlist)
             pathlist = [pathname]
-            # Clean netsvc Services
-            import netsvc
-            netsvc.SERVICES.clear()
+            _clear_netsvc_services()
         except ImportError:
             return False
-        else:
+        finally:
             if openfile:
                 openfile.close()
-                return True
+    return True
+
+
+def module_exists(module):
+    """Check if a python module exists.
+
+    This is used to check if a module has its own tests defined, Eg:
+    `addons.module_name.tests`
+
+    :param module: Module name to check
+    :return: True if exists or False if not
+    """
+    if importlib_util is None:
+        return _module_exists_with_imp(module)
+
+    try:
+        found = importlib_util.find_spec(module) is not None
+    except (ImportError, AttributeError, ValueError):
+        found = False
+    if found:
+        _clear_netsvc_services()
+    return found
 
 
 def get_dependencies(module, addons_path=None, deps=None):
@@ -171,7 +198,7 @@ def find_files(diff):
     """Return all the files implicated in a diff
     """
     paths = []
-    for line in re.findall(u"--- a/.*|\+\+\+ b/.*", diff):
+    for line in re.findall(u"--- a/.*|\\+\\+\\+ b/.*", diff):
         line = u'/'.join(line.split(u'/')[1:])
         paths.append(line)
     return list(set(paths))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,18 @@ class UpdateConfigTests(unittest.TestCase):
         self.assertEqual(result, {'existing': 1, 'added': 2})
 
 
+class ModuleExistsTests(unittest.TestCase):
+
+    def test_module_exists_returns_true_for_existing_module(self):
+        self.assertTrue(utils.module_exists('os'))
+
+    def test_module_exists_returns_true_for_existing_submodule(self):
+        self.assertTrue(utils.module_exists('email.mime'))
+
+    def test_module_exists_returns_false_for_missing_module(self):
+        self.assertFalse(utils.module_exists('destral_missing_module_for_tests'))
+
+
 class FindFilesTests(unittest.TestCase):
 
     def test_find_files_returns_unique_paths_from_diff(self):
@@ -31,6 +43,15 @@ class FindFilesTests(unittest.TestCase):
         paths = utils.find_files(diff)
         expected = ['foo/bar.py', 'README']
         self.assertEqual(sorted(paths), sorted(expected))
+
+    def test_find_files_accepts_unicode_diff(self):
+        diff = (
+            u"--- a/foo/bar.py\n"
+            u"+++ b/foo/bar.py\n"
+        )
+
+        paths = utils.find_files(diff)
+        self.assertEqual(paths, ['foo/bar.py'])
 
 
 class CoverageModulesPathTests(unittest.TestCase):


### PR DESCRIPTION
## Objectiu

Corregir la compatibilitat amb Python 3.12, on el mòdul estàndard `imp` ja no existeix.

Refs #175

## Canvis

- `module_exists()` usa `importlib.util.find_spec()` quan està disponible.
- Es manté fallback amb `imp.find_module()` per Python 2.7.
- La neteja de `netsvc.SERVICES` queda protegida perquè els tests unitaris puguin executar-se sense entorn ERP carregat.
- S'afegeixen tests unitaris per mòdul existent, submòdul existent i mòdul inexistent.
- S'elimina un `SyntaxWarning` de Python 3.12 en el patró regex de `find_files()`.

## Validació

Executat correctament:

```bash
# Python 2.7.18
python -m unittest discover tests

# Python 3.11.15
python -m unittest discover tests

# Python 3.12.3
python3 -m unittest discover tests

git diff --check
```

No he executat `mamba spec` perquè `mamba` no està instal·lat en aquest entorn local.
