### PR TITLE
Harden database name handling

### DIFF
--- a/destral/openerp.py
+++ b/destral/openerp.py
@@ -1,5 +1,11 @@
 import logging
-import time
+import re
+import uuid
+
+try:
+    string_types = (basestring,)
+except NameError:
+    string_types = (str,)
 
 from osconf import config_from_environment
 from typing import Optional
@@ -14,6 +20,27 @@ logger = logging.getLogger('destral.openerp')
 DEFAULT_USER = 1
 """Default user id
 """
+
+DATABASE_NAME_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+POSTGRES_IDENTIFIER_MAX_LENGTH = 63
+
+
+def generate_database_name():
+    return 'test_{}'.format(uuid.uuid4().hex)
+
+
+def validate_database_name(db_name):
+    if not isinstance(db_name, string_types):
+        raise ValueError('Invalid database name: {!r}'.format(db_name))
+    if len(db_name) > POSTGRES_IDENTIFIER_MAX_LENGTH:
+        raise ValueError('Database name is too long: {!r}'.format(db_name))
+    if not DATABASE_NAME_RE.match(db_name):
+        raise ValueError('Invalid database name: {!r}'.format(db_name))
+    return db_name
+
+
+def quote_database_identifier(db_name):
+    return '"{}"'.format(validate_database_name(db_name))
 
 
 def patched_pool_jobs(*args, **kwargs):
@@ -30,7 +57,7 @@ class OpenERPService(object):
     def __init__(self, **kwargs):
         """Creates a new OpenERP service.
 
-        :param \**kwargs: keyword arguments passed to the config
+        :param kwargs: keyword arguments passed to the config
         """
         config = config_from_environment('OPENERP', [], **kwargs)
         import service
@@ -66,7 +93,9 @@ class OpenERPService(object):
         :param template: use a template (name must be `base`) (default True)
         """
         if db_name is None:
-            db_name = 'test_' + str(int(time.time()))
+            db_name = generate_database_name()
+        db_name = validate_database_name(db_name)
+        quoted_db_name = quote_database_identifier(db_name)
         import sql_db
         conn = sql_db.db_connect('postgres')
         cursor = conn.cursor()
@@ -74,11 +103,11 @@ class OpenERPService(object):
             logger.info('Creating database %s', db_name)
             cursor.autocommit(True)
             if template:
-                cursor.execute('CREATE DATABASE {} WITH TEMPLATE base'.format(
-                    db_name
+                cursor.execute('CREATE DATABASE {} WITH TEMPLATE {}'.format(
+                    quoted_db_name, quote_database_identifier('base')
                 ))
             else:
-                cursor.execute('CREATE DATABASE {}'.format(db_name))
+                cursor.execute('CREATE DATABASE {}'.format(quoted_db_name))
             return db_name
         finally:
             cursor.close()
@@ -88,20 +117,23 @@ class OpenERPService(object):
         """Drop database from `self.db_name`
         """
         import sql_db
-        sql_db.close_db(self.db_name)
+        db_name = validate_database_name(self.db_name)
+        quoted_db_name = quote_database_identifier(db_name)
+        sql_db.close_db(db_name)
         conn = sql_db.db_connect('template1')
         cursor = conn.cursor()
         try:
-            logger.info('Droping database %s', self.db_name)
+            logger.info('Droping database %s', db_name)
             cursor.autocommit(True)
-            logger.info('Disconnect all sessions from database %s', self.db_name)
+            logger.info('Disconnect all sessions from database %s', db_name)
             cursor.execute(
                 "SELECT pg_terminate_backend(pg_stat_activity.pid) "
                 " FROM pg_stat_activity "
-                " WHERE pg_stat_activity.datname = '{}'"
-                " AND pid <> pg_backend_pid() ".format(self.db_name)
+                " WHERE pg_stat_activity.datname = %s"
+                " AND pid <> pg_backend_pid() ",
+                (db_name,)
             )
-            cursor.execute('DROP DATABASE ' + self.db_name)
+            cursor.execute('DROP DATABASE {}'.format(quoted_db_name))
         finally:
             cursor.close()
 
@@ -113,6 +145,8 @@ class OpenERPService(object):
 
     @db_name.setter
     def db_name(self, value):
+        if value:
+            value = validate_database_name(value)
         self.config['db_name'] = value
         if value:
             self.db, self.pool = self.pooler.get_db_and_pool(self.db_name)

--- a/tests/test_openerp.py
+++ b/tests/test_openerp.py
@@ -1,0 +1,167 @@
+# coding=utf-8
+import sys
+import types
+import unittest
+
+
+class FakeCursor(object):
+
+    def __init__(self):
+        self.statements = []
+        self.closed = False
+        self.autocommit_enabled = False
+
+    def autocommit(self, value):
+        self.autocommit_enabled = value
+
+    def execute(self, statement, params=None):
+        self.statements.append((statement, params))
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnection(object):
+
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+class FakeSqlDb(types.ModuleType):
+
+    def __init__(self):
+        types.ModuleType.__init__(self, 'sql_db')
+        self.Connection = object
+        self.cursor = FakeCursor()
+        self.closed = []
+        self.connected = []
+
+    def db_connect(self, db_name):
+        self.connected.append(db_name)
+        return FakeConnection(self.cursor)
+
+    def close_db(self, db_name):
+        self.closed.append(db_name)
+
+
+fake_typing = types.ModuleType('typing')
+fake_typing.Optional = object
+sys.modules.setdefault('typing', fake_typing)
+
+fake_sql_db = FakeSqlDb()
+sys.modules.setdefault('sql_db', fake_sql_db)
+
+fake_osconf = types.ModuleType('osconf')
+fake_osconf.config_from_environment = lambda *args, **kwargs: kwargs
+sys.modules.setdefault('osconf', fake_osconf)
+
+fake_psycopg2 = types.ModuleType('psycopg2')
+fake_psycopg2.OperationalError = Exception
+sys.modules.setdefault('psycopg2', fake_psycopg2)
+
+fake_osv = types.ModuleType('osv')
+fake_osv_osv = types.ModuleType('osv.osv')
+fake_osv_osv.osv_pool = object
+sys.modules.setdefault('osv', fake_osv)
+sys.modules.setdefault('osv.osv', fake_osv_osv)
+
+from destral import openerp
+
+
+class DatabaseNameTests(unittest.TestCase):
+
+    def setUp(self):
+        fake_sql_db.cursor = FakeCursor()
+        fake_sql_db.closed = []
+        fake_sql_db.connected = []
+
+    def test_generate_database_name_uses_safe_unique_prefix(self):
+        db_name = openerp.generate_database_name()
+
+        self.assertTrue(db_name.startswith('test_'))
+        self.assertEqual(openerp.validate_database_name(db_name), db_name)
+        self.assertLessEqual(len(db_name), openerp.POSTGRES_IDENTIFIER_MAX_LENGTH)
+
+    def test_validate_database_name_accepts_postgres_identifier_subset(self):
+        self.assertEqual(openerp.validate_database_name('test_database_1'), 'test_database_1')
+
+    def test_validate_database_name_rejects_unsafe_names(self):
+        unsafe_names = [
+            '',
+            '1test',
+            'test-db',
+            'test db',
+            'test;DROP_DATABASE_postgres',
+            'test"quote',
+            'a' * (openerp.POSTGRES_IDENTIFIER_MAX_LENGTH + 1),
+        ]
+        for db_name in unsafe_names:
+            with self.assertRaises(ValueError):
+                openerp.validate_database_name(db_name)
+
+    def test_create_database_quotes_database_identifier(self):
+        service = object.__new__(openerp.OpenERPService)
+
+        result = service.create_database(template=False, db_name='test_database')
+
+        self.assertEqual(result, 'test_database')
+        self.assertEqual(fake_sql_db.connected, ['postgres'])
+        self.assertEqual(fake_sql_db.closed, ['postgres'])
+        self.assertEqual(
+            fake_sql_db.cursor.statements,
+            [('CREATE DATABASE "test_database"', None)]
+        )
+
+    def test_create_database_with_template_quotes_identifiers(self):
+        service = object.__new__(openerp.OpenERPService)
+
+        service.create_database(template=True, db_name='test_database')
+
+        self.assertEqual(
+            fake_sql_db.cursor.statements,
+            [('CREATE DATABASE "test_database" WITH TEMPLATE "base"', None)]
+        )
+
+    def test_create_database_rejects_unsafe_name_before_connecting(self):
+        service = object.__new__(openerp.OpenERPService)
+
+        with self.assertRaises(ValueError):
+            service.create_database(template=False, db_name='test;DROP_DATABASE_postgres')
+
+        self.assertEqual(fake_sql_db.connected, [])
+
+    def test_drop_database_quotes_identifier_and_uses_parameter_for_datname(self):
+        service = object.__new__(openerp.OpenERPService)
+        service.config = {'db_name': 'test_database'}
+
+        service.drop_database()
+
+        self.assertEqual(fake_sql_db.connected, ['template1'])
+        self.assertEqual(fake_sql_db.closed, ['test_database'])
+        self.assertEqual(
+            fake_sql_db.cursor.statements,
+            [
+                (
+                    "SELECT pg_terminate_backend(pg_stat_activity.pid) "
+                    " FROM pg_stat_activity "
+                    " WHERE pg_stat_activity.datname = %s"
+                    " AND pid <> pg_backend_pid() ",
+                    ('test_database',)
+                ),
+                ('DROP DATABASE "test_database"', None),
+            ]
+        )
+
+    def test_db_name_setter_rejects_unsafe_names(self):
+        service = object.__new__(openerp.OpenERPService)
+        service.config = {}
+
+        with self.assertRaises(ValueError):
+            service.db_name = 'test;DROP_DATABASE_postgres'
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Objectiu

Endurir la gestió de noms de base de dades en `OpenERPService.create_database()` i `OpenERPService.drop_database()`.

Refs #176

## Canvis

- Generació de BBDD temporal amb `uuid4` en lloc de `int(time.time())`, evitant col·lisions dins el mateix segon.
- Validació explícita de noms de BBDD amb whitelist compatible amb identificadors PostgreSQL:
  - `^[A-Za-z_][A-Za-z0-9_]*$`
  - màxim 63 caràcters.
- Quoting d'identificadors en `CREATE DATABASE` i `DROP DATABASE`.
- `pg_stat_activity.datname` passa a usar paràmetre SQL en lloc de format string.
- Validació també al setter `db_name`, cobrint valors via configuració/CLI.
- Tests unitaris sense PostgreSQL real per generació, validació, SQL generat i rebuig de noms insegurs.

## Validació

Executat correctament:

```bash
# Python 2.7.18
python -m unittest discover tests

# Python 3.11.15
python -m unittest discover tests

git diff --check
```

No he executat `mamba spec` perquè `mamba` no està instal·lat en aquest entorn local.

Nota: Python 3.12 sobre `master` encara queda bloquejat per #175 (`imp` eliminat). Aquesta PR no depèn funcionalment de PostgreSQL real per als tests afegits.
