### PR TITLE
feat: add quiet output mode for destral

### DIFF
--- a/destral/cli.py
+++ b/destral/cli.py
@@ -2,6 +2,7 @@ import os
 import sys
 import subprocess
 import logging
+import traceback
 import requests
 
 import click
@@ -12,6 +13,7 @@ from destral.linter import run_linter
 from destral.openerp import OpenERPService
 from destral.patch import RestorePatchedRegisterAll
 from destral.cover import OOCoverage
+from destral.output import QuietOutputCapture
 
 LOG_FORMAT = '%(asctime)s:{0}'.format(logging.BASIC_FORMAT)
 
@@ -38,9 +40,45 @@ logger = logging.getLogger('destral.cli')
     '--coverage-html-report', type=click.STRING, nargs=1, default="", help="Coverage HTML report path"
 )
 @click.option('--coverage-without-test-lines', type=click.BOOL, default=True)
+@click.option(
+    '--quiet', '--silent', 'quiet', type=click.BOOL, default=False,
+    is_flag=True,
+    help=(
+        'Capture verbose output and only print a short failure summary. '
+        'Default output is unchanged when this option is not used.'
+    )
+)
 def destral(modules, tests, all_tests=None, enable_coverage=None,
             report_coverage=None, report_junitxml=None, dropdb=None,
             requirements=None, **kwargs):
+    quiet = kwargs.pop('quiet')
+    quiet_output = QuietOutputCapture(quiet)
+    return_code = 1
+    with quiet_output:
+        try:
+            return_code = run_destral(
+                modules, tests, all_tests=all_tests,
+                enable_coverage=enable_coverage,
+                report_coverage=report_coverage,
+                report_junitxml=report_junitxml, dropdb=dropdb,
+                requirements=requirements, **kwargs
+            )
+        except Exception:
+            if quiet:
+                traceback.print_exc()
+            else:
+                raise
+    if quiet:
+        if return_code:
+            quiet_output.emit_failure_summary(return_code)
+        else:
+            quiet_output.cleanup_success()
+    sys.exit(return_code)
+
+
+def run_destral(modules, tests, all_tests=None, enable_coverage=None,
+                report_coverage=None, report_junitxml=None, dropdb=None,
+                requirements=None, **kwargs):
     os.environ['OPENERP_DESTRAL_MODE'] = "1"
     enable_lint = kwargs.pop('enable_lint')
     constraints_file = kwargs.pop('constraints_file')
@@ -161,6 +199,7 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
             except Exception as e:
                 logger.error('Suite not found: {}'.format(e))
                 service.shutdown(1)
+                return 1
             suite.drop_database = dropdb
             suite.config['all_tests'] = all_tests
             if all_tests:
@@ -198,7 +237,7 @@ def destral(modules, tests, all_tests=None, enable_coverage=None,
         return_code = 1
 
     service.shutdown(return_code)
-    sys.exit(return_code)
+    return return_code
 
 
 if __name__ == '__main__':

--- a/destral/cli.py
+++ b/destral/cli.py
@@ -41,8 +41,7 @@ logger = logging.getLogger('destral.cli')
 )
 @click.option('--coverage-without-test-lines', type=click.BOOL, default=True)
 @click.option(
-    '--quiet', '--silent', 'quiet', type=click.BOOL, default=False,
-    is_flag=True,
+    '--quiet', type=click.BOOL, default=False, is_flag=True,
     help=(
         'Capture verbose output and only print a short failure summary. '
         'Default output is unchanged when this option is not used.'

--- a/destral/output.py
+++ b/destral/output.py
@@ -1,0 +1,124 @@
+# coding=utf-8
+"""Output helpers for destral command line execution."""
+from __future__ import print_function
+
+import os
+import sys
+import tempfile
+
+
+class QuietOutputCapture(object):
+    """Capture stdout/stderr to a file and print a short failure summary.
+
+    The implementation redirects file descriptors and Python stream objects so
+    logging handlers, subprocesses and click test runners are captured. This
+    keeps the default CLI behaviour untouched and makes quiet mode useful for
+    automation that cannot afford very large terminal output.
+    """
+
+    def __init__(self, enabled=False, tail_lines=80):
+        self.enabled = enabled
+        self.tail_lines = tail_lines
+        self.path = None
+        self._fd = None
+        self._stdout_fd = None
+        self._stderr_fd = None
+        self._stdout_stream = None
+        self._stderr_stream = None
+        self._stdout_proxy = None
+        self._stderr_proxy = None
+
+    def __enter__(self):
+        if not self.enabled:
+            return self
+        fd, self.path = tempfile.mkstemp(
+            prefix='destral-quiet-', suffix='.log'
+        )
+        self._fd = fd
+        self._stdout_fd = os.dup(1)
+        self._stderr_fd = os.dup(2)
+        self._stdout_stream = sys.stdout
+        self._stderr_stream = sys.stderr
+        self._flush_standard_streams()
+        os.dup2(self._fd, 1)
+        os.dup2(self._fd, 2)
+        self._stdout_proxy = os.fdopen(os.dup(self._fd), 'w')
+        self._stderr_proxy = os.fdopen(os.dup(self._fd), 'w')
+        sys.stdout = self._stdout_proxy
+        sys.stderr = self._stderr_proxy
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.enabled:
+            return False
+        self.restore()
+        return False
+
+    def restore(self):
+        if self._fd is None:
+            return
+        self._flush_standard_streams()
+        if self._stdout_stream is not None:
+            sys.stdout = self._stdout_stream
+        if self._stderr_stream is not None:
+            sys.stderr = self._stderr_stream
+        self._close_proxy(self._stdout_proxy)
+        self._close_proxy(self._stderr_proxy)
+        os.dup2(self._stdout_fd, 1)
+        os.dup2(self._stderr_fd, 2)
+        os.close(self._stdout_fd)
+        os.close(self._stderr_fd)
+        os.close(self._fd)
+        self._fd = None
+        self._stdout_fd = None
+        self._stderr_fd = None
+        self._stdout_stream = None
+        self._stderr_stream = None
+        self._stdout_proxy = None
+        self._stderr_proxy = None
+
+    def cleanup_success(self):
+        if self.enabled and self.path and os.path.exists(self.path):
+            os.unlink(self.path)
+
+    def emit_failure_summary(self, return_code=1):
+        if not self.enabled:
+            return
+        print('destral failed with exit code {}'.format(return_code), file=sys.stderr)
+        print('Full captured output: {}'.format(self.path), file=sys.stderr)
+        tail = self.tail()
+        if tail:
+            print('', file=sys.stderr)
+            print('Last {} captured lines:'.format(self.tail_lines), file=sys.stderr)
+            print(tail, file=sys.stderr)
+
+    def tail(self):
+        if not self.path or not os.path.exists(self.path):
+            return ''
+        with open(self.path, 'rb') as output_file:
+            data = output_file.read()
+        if not data:
+            return ''
+        try:
+            text = data.decode('utf-8')
+        except UnicodeDecodeError:
+            text = data.decode('utf-8', 'replace')
+        lines = text.splitlines()
+        return '\n'.join(lines[-self.tail_lines:])
+
+    @staticmethod
+    def _flush_standard_streams():
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.flush()
+            except Exception:
+                pass
+
+    @staticmethod
+    def _close_proxy(proxy):
+        if proxy is None:
+            return
+        try:
+            proxy.close()
+        except Exception:
+            pass

--- a/destral/output.py
+++ b/destral/output.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import os
 import sys
 import tempfile
+from collections import deque
 
 
 class QuietOutputCapture(object):
@@ -96,15 +97,15 @@ class QuietOutputCapture(object):
         if not self.path or not os.path.exists(self.path):
             return ''
         with open(self.path, 'rb') as output_file:
-            data = output_file.read()
-        if not data:
+            tail_lines = deque(output_file, maxlen=self.tail_lines)
+        if not tail_lines:
             return ''
+        data = b''.join(tail_lines)
         try:
             text = data.decode('utf-8')
         except UnicodeDecodeError:
             text = data.decode('utf-8', 'replace')
-        lines = text.splitlines()
-        return '\n'.join(lines[-self.tail_lines:])
+        return '\n'.join(text.splitlines())
 
     @staticmethod
     def _flush_standard_streams():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+from __future__ import print_function
+
+import os
+import sys
+import tempfile
+import unittest
+
+from destral.output import QuietOutputCapture
+
+
+class QuietOutputCaptureTests(unittest.TestCase):
+
+    def test_disabled_capture_does_not_create_log_file(self):
+        capture = QuietOutputCapture(enabled=False)
+
+        with capture:
+            pass
+
+        self.assertIsNone(capture.path)
+
+    def test_enabled_capture_writes_stdout_and_stderr_to_file(self):
+        capture = QuietOutputCapture(enabled=True, tail_lines=10)
+        original_stdout_fd = os.dup(1)
+        original_stderr_fd = os.dup(2)
+        try:
+            with capture:
+                print('captured stdout')
+                print('captured stderr', file=sys.stderr)
+
+            self.assertIn('captured stdout', capture.tail())
+            self.assertIn('captured stderr', capture.tail())
+        finally:
+            os.dup2(original_stdout_fd, 1)
+            os.dup2(original_stderr_fd, 2)
+            os.close(original_stdout_fd)
+            os.close(original_stderr_fd)
+            if capture.path and os.path.exists(capture.path):
+                os.unlink(capture.path)
+
+    def test_tail_limits_returned_lines(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            with open(path, 'w') as output_file:
+                output_file.write('one\ntwo\nthree\n')
+            capture = QuietOutputCapture(enabled=True, tail_lines=2)
+            capture.path = path
+
+            self.assertEqual(capture.tail(), 'two\nthree')
+        finally:
+            os.unlink(path)
+
+    def test_cleanup_success_removes_capture_file(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        capture = QuietOutputCapture(enabled=True)
+        capture.path = path
+
+        capture.cleanup_success()
+
+        self.assertFalse(os.path.exists(path))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -21,6 +21,8 @@ class QuietOutputCaptureTests(unittest.TestCase):
 
     def test_enabled_capture_writes_stdout_and_stderr_to_file(self):
         capture = QuietOutputCapture(enabled=True, tail_lines=10)
+        original_stdout = sys.stdout
+        original_stderr = sys.stderr
         original_stdout_fd = os.dup(1)
         original_stderr_fd = os.dup(2)
         try:
@@ -30,9 +32,11 @@ class QuietOutputCaptureTests(unittest.TestCase):
 
             self.assertIn('captured stdout', capture.tail())
             self.assertIn('captured stderr', capture.tail())
+            self.assertIs(sys.stdout, original_stdout)
+            self.assertIs(sys.stderr, original_stderr)
+            self.assertTrue(os.path.sameopenfile(1, original_stdout_fd))
+            self.assertTrue(os.path.sameopenfile(2, original_stderr_fd))
         finally:
-            os.dup2(original_stdout_fd, 1)
-            os.dup2(original_stderr_fd, 2)
             os.close(original_stdout_fd)
             os.close(original_stderr_fd)
             if capture.path and os.path.exists(capture.path):


### PR DESCRIPTION
## Resumen

Añade un modo opt-in `--quiet` al CLI de `destral` para reducir el ruido de salida cuando lo ejecutan agentes AI o automatizaciones.

Por defecto el comportamiento no cambia.

## Cambios

- Nuevo helper `QuietOutputCapture` que captura `stdout`/`stderr` en un fichero temporal.
- Nuevo flag CLI `--quiet`.
- Si la ejecución pasa en quiet mode, no imprime output y elimina el log temporal.
- Si falla, imprime un resumen corto con:
  - exit code;
  - ruta del output completo capturado;
  - últimas líneas capturadas para diagnóstico rápido.
- Se mantiene el exit code original.
- Tests unitarios del helper de captura.
- Lectura acotada de las últimas líneas capturadas para evitar cargar logs grandes completos en memoria.

## Validación

- `python -m unittest discover tests` en Python 2.7 con entorno ERP local.
- `python3 -m unittest tests.test_output`.
- Smoke test del CLI con `--quiet` visible en `--help`.

Closes #181

