### PR TITLE
Add class-level cursor patching for OOTestCaseWithCursor

### DIFF
--- a/destral/testing.py
+++ b/destral/testing.py
@@ -8,6 +8,7 @@ from destral.junitxml_testing import JUnitXMLResult, LoggerStream
 from destral.junitxml_testing import JUnitXMLApplicationFactory
 from destral.junitxml_testing import JUnitXMLMambaFormatter
 from destral.openerp import OpenERPService
+from destral.patch import PatchNewCursors
 from destral.transaction import Transaction
 from destral.utils import module_exists
 from osconf import config_from_environment
@@ -113,14 +114,21 @@ class OOTestCase(unittest.TestCase):
 
 
 class OOTestCaseWithCursor(OOTestCase):
+    _patch_cursors = False
 
     def setUp(self):
+        self._patch_new_cursors = None
         self.txn = Transaction().start(self.database)
         self.cursor = self.txn.cursor
         self.uid = self.txn.user
+        if self._patch_cursors:
+            self._patch_new_cursors = PatchNewCursors()
+            self._patch_new_cursors.patch()
         _ws_info.push(WebServiceTracker(uid=self.uid))
 
     def tearDown(self):
+        if self._patch_new_cursors:
+            self._patch_new_cursors.unpatch()
         self.txn.stop()
         _ws_info.pop()
 

--- a/tests/test_openerp.py
+++ b/tests/test_openerp.py
@@ -4,6 +4,23 @@ import types
 import unittest
 
 
+previous_modules = {}
+
+
+def set_fake_module(name, module):
+    previous_modules.setdefault(name, sys.modules.get(name))
+    sys.modules[name] = module
+
+
+def tearDownModule():
+    for name, module in list(previous_modules.items()):
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+        previous_modules.pop(name, None)
+
+
 class FakeCursor(object):
 
     def __init__(self):
@@ -47,36 +64,48 @@ class FakeSqlDb(types.ModuleType):
         self.closed.append(db_name)
 
 
-fake_typing = types.ModuleType('typing')
-fake_typing.Optional = object
-sys.modules.setdefault('typing', fake_typing)
+try:
+    import typing  # noqa
+except ImportError:
+    fake_typing = types.ModuleType('typing')
+    fake_typing.Optional = object
+    set_fake_module('typing', fake_typing)
 
 fake_sql_db = FakeSqlDb()
-sys.modules.setdefault('sql_db', fake_sql_db)
+set_fake_module('sql_db', fake_sql_db)
 
 fake_osconf = types.ModuleType('osconf')
 fake_osconf.config_from_environment = lambda *args, **kwargs: kwargs
-sys.modules.setdefault('osconf', fake_osconf)
+set_fake_module('osconf', fake_osconf)
 
 fake_psycopg2 = types.ModuleType('psycopg2')
 fake_psycopg2.OperationalError = Exception
-sys.modules.setdefault('psycopg2', fake_psycopg2)
+set_fake_module('psycopg2', fake_psycopg2)
 
 fake_osv = types.ModuleType('osv')
 fake_osv_osv = types.ModuleType('osv.osv')
 fake_osv_osv.osv_pool = object
-sys.modules.setdefault('osv', fake_osv)
-sys.modules.setdefault('osv.osv', fake_osv_osv)
+set_fake_module('osv', fake_osv)
+set_fake_module('osv.osv', fake_osv_osv)
 
 from destral import openerp
+tearDownModule()
 
 
 class DatabaseNameTests(unittest.TestCase):
 
     def setUp(self):
+        self.previous_sql_db = sys.modules.get('sql_db')
+        sys.modules['sql_db'] = fake_sql_db
         fake_sql_db.cursor = FakeCursor()
         fake_sql_db.closed = []
         fake_sql_db.connected = []
+
+    def tearDown(self):
+        if self.previous_sql_db is None:
+            sys.modules.pop('sql_db', None)
+        else:
+            sys.modules['sql_db'] = self.previous_sql_db
 
     def test_generate_database_name_uses_safe_unique_prefix(self):
         db_name = openerp.generate_database_name()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+import unittest
+
+from mock import Mock, patch
+
+from destral import testing
+
+
+class FakeOpenERP(object):
+    db_name = 'test_db'
+
+
+class FakeTransaction(object):
+
+    def __init__(self, events):
+        self.events = events
+        self.cursor = 'cursor'
+        self.user = 1
+
+    def start(self, database):
+        self.events.append(('start', database))
+        return self
+
+    def stop(self):
+        self.events.append('stop')
+
+
+class FakePatchNewCursors(object):
+
+    def __init__(self, events):
+        self.events = events
+
+    def patch(self):
+        self.events.append('patch')
+
+    def unpatch(self):
+        self.events.append('unpatch')
+
+
+class FakeWsInfo(object):
+
+    def __init__(self, events):
+        self.events = events
+
+    def push(self, tracker):
+        self.events.append(('push', tracker))
+
+    def pop(self):
+        self.events.append('pop')
+
+
+class CursorPatchTests(unittest.TestCase):
+
+    def _run_case(self, case_class):
+        events = []
+        test_case = case_class(methodName='runTest')
+        test_case.openerp = FakeOpenERP()
+        transaction = FakeTransaction(events)
+        cursor_patch = FakePatchNewCursors(events)
+        tracker = Mock(name='tracker')
+
+        with patch.object(testing, 'Transaction', return_value=transaction), \
+                patch.object(testing, 'PatchNewCursors', return_value=cursor_patch), \
+                patch.object(testing, '_ws_info', FakeWsInfo(events)), \
+                patch.object(testing, 'WebServiceTracker', return_value=tracker):
+            test_case.setUp()
+            test_case.tearDown()
+
+        return events, tracker
+
+    def test_cursor_patching_is_disabled_by_default(self):
+        class TestCase(testing.OOTestCaseWithCursor):
+            def runTest(self):
+                pass
+
+        events, tracker = self._run_case(TestCase)
+
+        self.assertEqual(
+            events,
+            [
+                ('start', 'test_db'),
+                ('push', tracker),
+                'stop',
+                'pop',
+            ]
+        )
+
+    def test_cursor_patching_can_be_enabled_for_the_whole_test_class(self):
+        class TestCase(testing.OOTestCaseWithCursor):
+            _patch_cursors = True
+
+            def runTest(self):
+                pass
+
+        events, tracker = self._run_case(TestCase)
+
+        self.assertEqual(
+            events,
+            [
+                ('start', 'test_db'),
+                'patch',
+                ('push', tracker),
+                'unpatch',
+                'stop',
+                'pop',
+            ]
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,9 +1,18 @@
 # coding=utf-8
+from contextlib import contextmanager
 import unittest
 
-from mock import Mock, patch
-
 from destral import testing
+
+
+@contextmanager
+def patched_attr(obj, name, value):
+    old_value = getattr(obj, name)
+    setattr(obj, name, value)
+    try:
+        yield
+    finally:
+        setattr(obj, name, old_value)
 
 
 class FakeOpenERP(object):
@@ -57,12 +66,12 @@ class CursorPatchTests(unittest.TestCase):
         test_case.openerp = FakeOpenERP()
         transaction = FakeTransaction(events)
         cursor_patch = FakePatchNewCursors(events)
-        tracker = Mock(name='tracker')
+        tracker = object()
 
-        with patch.object(testing, 'Transaction', return_value=transaction), \
-                patch.object(testing, 'PatchNewCursors', return_value=cursor_patch), \
-                patch.object(testing, '_ws_info', FakeWsInfo(events)), \
-                patch.object(testing, 'WebServiceTracker', return_value=tracker):
+        with patched_attr(testing, 'Transaction', lambda: transaction), \
+                patched_attr(testing, 'PatchNewCursors', lambda: cursor_patch), \
+                patched_attr(testing, '_ws_info', FakeWsInfo(events)), \
+                patched_attr(testing, 'WebServiceTracker', lambda uid: tracker):
             test_case.setUp()
             test_case.tearDown()
 


### PR DESCRIPTION
## Summary
- Add `_patch_cursors = False` as a class-level option on `OOTestCaseWithCursor`.
- When enabled by subclasses, `setUp` applies `PatchNewCursors` for every test method and `tearDown` restores it before closing the transaction.
- Cover default and enabled behavior with focused unit tests.
- Keep the new tests compatible with `unittest discover` on Python 2 and Python 3 by avoiding the external `mock` import and scoping `test_openerp` module fakes.

## Tests
- `/home/openclaw/projects/gisce-developer/env/with-erp-destral-env /home/openclaw/.pyenv/versions/erp3/bin/python -m unittest discover tests`
- `/home/openclaw/projects/gisce-developer/env/with-erp-destral-env /home/openclaw/.pyenv/versions/erp2/bin/python -m unittest discover tests`

Closes #183
